### PR TITLE
detect and broadcast changes in config to config listeners

### DIFF
--- a/src/main/java/cloud/prefab/client/config/ConfigChangeEvent.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigChangeEvent.java
@@ -1,0 +1,68 @@
+package cloud.prefab.client.config;
+
+import cloud.prefab.domain.Prefab;
+import cloud.prefab.domain.Prefab.ConfigValue;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+public class ConfigChangeEvent {
+
+  private final String key;
+  private final Optional<Prefab.ConfigValue> oldValue;
+  private final Optional<Prefab.ConfigValue> newValue;
+
+  public ConfigChangeEvent(
+    String key,
+    Optional<ConfigValue> oldValue,
+    Optional<ConfigValue> newValue
+  ) {
+    this.key = key;
+    this.oldValue = oldValue;
+    this.newValue = newValue;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public Optional<ConfigValue> getOldValue() {
+    return oldValue;
+  }
+
+  public Optional<ConfigValue> getNewValue() {
+    return newValue;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj instanceof ConfigChangeEvent) {
+      final ConfigChangeEvent that = (ConfigChangeEvent) obj;
+      return (
+        Objects.equals(this.key, that.key) &&
+        Objects.equals(this.oldValue, that.oldValue) &&
+        Objects.equals(this.newValue, that.newValue)
+      );
+    }
+
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, oldValue, newValue);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", "ConfigChangeEvent[", "]")
+      .add("key='" + key + "'")
+      .add("oldValue=" + oldValue)
+      .add("newValue=" + newValue)
+      .toString();
+  }
+}

--- a/src/main/java/cloud/prefab/client/config/ConfigChangeListener.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigChangeListener.java
@@ -1,8 +1,5 @@
 package cloud.prefab.client.config;
 
-import cloud.prefab.domain.Prefab;
-import java.util.Map;
-
 public interface ConfigChangeListener {
-  void prefabConfigUpdateCallback(Map<String, Prefab.ConfigValue> changes);
+  void onChange(ConfigChangeEvent changeEvent);
 }

--- a/src/main/java/cloud/prefab/client/config/ConfigChangeListener.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigChangeListener.java
@@ -1,0 +1,8 @@
+package cloud.prefab.client.config;
+
+import cloud.prefab.domain.Prefab;
+import java.util.Map;
+
+public interface ConfigChangeListener {
+  void prefabConfigUpdateCallback(Map<String, Prefab.ConfigValue> changes);
+}

--- a/src/main/java/cloud/prefab/client/config/ConfigLoader.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigLoader.java
@@ -1,18 +1,17 @@
 package cloud.prefab.client.config;
 
 import cloud.prefab.client.Options;
-import cloud.prefab.client.PrefabCloudClient;
 import cloud.prefab.domain.Prefab;
+import cloud.prefab.domain.Prefab.Config;
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -20,19 +19,19 @@ import org.yaml.snakeyaml.Yaml;
 public class ConfigLoader {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConfigLoader.class);
+
   private final Options options;
-
-  private ConcurrentMap<String, Prefab.Config> apiConfig = new ConcurrentHashMap<>();
-  private long highwaterMark = 0;
-
-  private Map<String, Prefab.Config> classPathConfig;
-
-  private Map<String, Prefab.Config> overrideConfig;
+  private final ConcurrentMap<String, Prefab.Config> apiConfig;
+  private final AtomicLong highwaterMark;
+  private final ImmutableMap<String, Config> classPathConfig;
+  private final ImmutableMap<String, Prefab.Config> overrideConfig;
 
   public ConfigLoader(Options options) {
     this.options = options;
-    classPathConfig = loadClasspathConfig();
-    overrideConfig = loadOverrideConfig();
+    this.apiConfig = new ConcurrentHashMap<>();
+    this.highwaterMark = new AtomicLong(0);
+    this.classPathConfig = loadClasspathConfig();
+    this.overrideConfig = loadOverrideConfig();
   }
 
   /**
@@ -41,15 +40,13 @@ public class ConfigLoader {
    * layer the overrides on last
    */
   public Map<String, Prefab.Config> calcConfig() {
-    Map<String, Prefab.Config> rtn = new HashMap<>(classPathConfig);
-    apiConfig.forEach((k, v) -> {
-      rtn.put(k, v);
-    });
+    ImmutableMap.Builder<String, Prefab.Config> builder = ImmutableMap.builder();
 
-    overrideConfig.forEach((k, v) -> {
-      rtn.put(k, v);
-    });
-    return rtn;
+    builder.putAll(classPathConfig);
+    builder.putAll(apiConfig);
+    builder.putAll(overrideConfig);
+
+    return builder.buildKeepingLast();
   }
 
   public void set(Prefab.Config config) {
@@ -66,32 +63,27 @@ public class ConfigLoader {
   }
 
   private void recomputeHighWaterMark() {
-    Optional<Prefab.Config> highwaterMarkDelta = apiConfig
+    long highwaterMarkDelta = apiConfig
       .values()
       .stream()
-      .max(
-        new Comparator<Prefab.Config>() {
-          @Override
-          public int compare(Prefab.Config o1, Prefab.Config o2) {
-            return (int) (o1.getId() - o2.getId());
-          }
-        }
-      );
+      .mapToLong(Prefab.Config::getId)
+      .max()
+      .orElse(0L);
 
-    highwaterMark = highwaterMarkDelta.isPresent() ? highwaterMarkDelta.get().getId() : 0;
+    highwaterMark.set(highwaterMarkDelta);
   }
 
-  private Map<String, Prefab.Config> loadClasspathConfig() {
-    Map<String, Prefab.Config> rtn = new HashMap<>();
+  private ImmutableMap<String, Prefab.Config> loadClasspathConfig() {
+    ImmutableMap.Builder<String, Prefab.Config> builder = ImmutableMap.builder();
 
     for (String env : options.getAllPrefabEnvs()) {
       final String file = String.format(".prefab.%s.config.yaml", env);
       final InputStream resourceAsStream =
         this.getClass().getClassLoader().getResourceAsStream(file);
-      loadFileTo(resourceAsStream, rtn, file);
+      loadFileTo(resourceAsStream, builder, file);
     }
 
-    return rtn;
+    return builder.buildKeepingLast();
   }
 
   private Prefab.Config toValue(Object obj) {
@@ -111,8 +103,8 @@ public class ConfigLoader {
       .build();
   }
 
-  private Map<String, Prefab.Config> loadOverrideConfig() {
-    Map<String, Prefab.Config> rtn = new HashMap<>();
+  private ImmutableMap<String, Prefab.Config> loadOverrideConfig() {
+    ImmutableMap.Builder<String, Prefab.Config> builder = ImmutableMap.builder();
 
     File dir = new File(options.getConfigOverrideDir());
     for (String env : options.getAllPrefabEnvs()) {
@@ -121,35 +113,34 @@ public class ConfigLoader {
 
       if (file.exists()) {
         try (InputStream inputStream = new FileInputStream(file)) {
-          loadFileTo(inputStream, rtn, fileName);
+          loadFileTo(inputStream, builder, fileName);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }
       }
     }
 
-    return rtn;
+    return builder.buildKeepingLast();
   }
 
   private void loadFileTo(
     InputStream inputStream,
-    Map<String, Prefab.Config> rtn,
+    ImmutableMap.Builder<String, Prefab.Config> builder,
     String file
   ) {
     LOG.info("Load Default File {}", file);
     Yaml yaml = new Yaml();
     Map<String, Object> obj = yaml.load(inputStream);
     obj.forEach((k, v) -> {
-      loadKeyValue(k, v, rtn, file);
-      rtn.put(k, toValue(v));
+      loadKeyValue(k, v, builder);
+      builder.put(k, toValue(v));
     });
   }
 
   private void loadKeyValue(
     String k,
     Object v,
-    Map<String, Prefab.Config> rtn,
-    String file
+    ImmutableMap.Builder<String, Prefab.Config> builder
   ) {
     if (v instanceof Map) {
       Map<String, Object> map = (Map<String, Object>) v;
@@ -159,14 +150,14 @@ public class ConfigLoader {
         if (nest.getKey().equals("_")) {
           nestedKey = k;
         }
-        loadKeyValue(nestedKey, nest.getValue(), rtn, file);
+        loadKeyValue(nestedKey, nest.getValue(), builder);
       }
     } else {
-      rtn.put(k, toValue(v));
+      builder.put(k, toValue(v));
     }
   }
 
   public long getHighwaterMark() {
-    return highwaterMark;
+    return highwaterMark.get();
   }
 }

--- a/src/main/java/cloud/prefab/client/config/ConfigResolver.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigResolver.java
@@ -57,7 +57,7 @@ public class ConfigResolver {
   /**
    * Return the changed config values since last update()
    */
-  public List<ConfigChangeEvent> update() {
+  public synchronized List<ConfigChangeEvent> update() {
     // store the old map
     final Map<String, Prefab.ConfigValue> before = localMap
       .get()
@@ -177,7 +177,7 @@ public class ConfigResolver {
         }
       });
 
-    localMap.set(store.build());
+    localMap.set(store.buildKeepingLast());
   }
 
   NamespaceMatch evaluateMatch(String namespace, String baseNamespace) {

--- a/src/main/java/cloud/prefab/client/config/ConfigResolver.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigResolver.java
@@ -23,11 +23,11 @@ public class ConfigResolver {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConfigResolver.class);
 
-  private final String NAMESPACE_DELIMITER = "\\.";
+  private static final String NAMESPACE_DELIMITER = "\\.";
 
   private final PrefabCloudClient baseClient;
   private final ConfigLoader configLoader;
-  private AtomicReference<ImmutableMap<String, ResolverElement>> localMap = new AtomicReference<>(
+  private final AtomicReference<ImmutableMap<String, ResolverElement>> localMap = new AtomicReference<>(
     ImmutableMap.of()
   );
 

--- a/src/main/java/cloud/prefab/client/config/ResolverElement.java
+++ b/src/main/java/cloud/prefab/client/config/ResolverElement.java
@@ -2,6 +2,7 @@ package cloud.prefab.client.config;
 
 import cloud.prefab.domain.Prefab;
 import com.google.common.base.MoreObjects;
+import java.util.Objects;
 
 public class ResolverElement implements Comparable<ResolverElement> {
 

--- a/src/test/java/cloud/prefab/client/ConfigClientTest.java
+++ b/src/test/java/cloud/prefab/client/ConfigClientTest.java
@@ -2,8 +2,13 @@ package cloud.prefab.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import cloud.prefab.client.config.ConfigChangeListener;
 import cloud.prefab.domain.Prefab;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -47,5 +52,31 @@ class ConfigClientTest {
 
     ConfigClient configClient = new ConfigClient(baseClient);
     assertEquals(false, configClient.get("key").isPresent());
+  }
+
+  @Test
+  void broadcast() {
+    final PrefabCloudClient baseClient = new PrefabCloudClient(
+      new Options()
+        .setApikey("0-P1-E1-SDK-1234-123-23")
+        .setInitializationTimeoutSec(1)
+        .setOnInitializationFailure(Options.OnInitializationFailure.UNLOCK)
+    );
+
+    ConfigClient configClient = new ConfigClient(baseClient);
+
+    ConfigChangeListener mockConfigChangeListener = mock(ConfigChangeListener.class);
+    configClient.addConfigChangeListener(mockConfigChangeListener);
+    assertEquals(false, configClient.get("key").isPresent());
+
+    final Map<String, Prefab.ConfigValue> expected = Map.of(
+      "sample_bool",
+      Prefab.ConfigValue.newBuilder().setBool(true).build(),
+      "sample",
+      Prefab.ConfigValue.newBuilder().setString("default sample value").build()
+    );
+
+    verify(mockConfigChangeListener).prefabConfigUpdateCallback(Map.of());
+    verify(mockConfigChangeListener).prefabConfigUpdateCallback(eq(expected));
   }
 }

--- a/src/test/java/cloud/prefab/client/config/ConfigResolverTest.java
+++ b/src/test/java/cloud/prefab/client/config/ConfigResolverTest.java
@@ -10,7 +10,6 @@ import cloud.prefab.domain.Prefab;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,10 +36,38 @@ public class ConfigResolverTest {
   @Test
   public void testUpdateChangeDetection() {
     // original testData() has 2 keys
-    assertThat(resolver.update()).isEqualTo(Set.of("key1", "key2"));
+    assertThat(resolver.update())
+      .containsExactlyInAnyOrder(
+        new ConfigChangeEvent(
+          "key1",
+          Optional.empty(),
+          Optional.of(
+            Prefab.ConfigValue.newBuilder().setString("value_no_env_default").build()
+          )
+        ),
+        new ConfigChangeEvent(
+          "key2",
+          Optional.empty(),
+          Optional.of(Prefab.ConfigValue.newBuilder().setString("valueB2").build())
+        )
+      );
 
     when(mockLoader.calcConfig()).thenReturn(testDataAddingKey3andTombstoningKey1());
-    assertThat(resolver.update()).isEqualTo(Set.of("key1", "key3"));
+    assertThat(resolver.update())
+      .containsExactlyInAnyOrder(
+        new ConfigChangeEvent(
+          "key1",
+          Optional.of(
+            Prefab.ConfigValue.newBuilder().setString("value_no_env_default").build()
+          ),
+          Optional.empty()
+        ),
+        new ConfigChangeEvent(
+          "key3",
+          Optional.empty(),
+          Optional.of(Prefab.ConfigValue.newBuilder().setString("key3").build())
+        )
+      );
   }
 
   private Map<String, Prefab.Config> testDataAddingKey3andTombstoningKey1() {


### PR DESCRIPTION
Enable customers to get dynamic logging by adding a config change broadcast. 

Users can create a listener, listen for `log_level` keys and set their log levels as needed. 