### PR TITLE
Add dynamic logging listeners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
         <version>${dep.protobuf.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java-util</artifactId>
+        <version>${dep.protobuf.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-api</artifactId>
         <version>${dep.grpc.version}</version>
@@ -134,12 +139,20 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -186,11 +199,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.4.3</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.9.0</version>
@@ -73,6 +78,21 @@
         <version>1.3.2</version>
       </dependency>
       <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>1.2.17</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>2.19.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>2.19.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>3.23.1</version>
@@ -97,7 +117,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.36</version>
+        <version>2.0.3</version>
       </dependency>
       <dependency>
         <groupId>org.yaml</groupId>
@@ -108,6 +128,11 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -127,6 +152,21 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/cloud/prefab/client/ConfigClient.java
+++ b/src/main/java/cloud/prefab/client/ConfigClient.java
@@ -4,6 +4,7 @@ import cloud.prefab.client.config.ConfigChangeEvent;
 import cloud.prefab.client.config.ConfigChangeListener;
 import cloud.prefab.client.config.ConfigLoader;
 import cloud.prefab.client.config.ConfigResolver;
+import cloud.prefab.client.config.LoggingConfigListener;
 import cloud.prefab.client.value.LiveBoolean;
 import cloud.prefab.client.value.LiveDouble;
 import cloud.prefab.client.value.LiveLong;
@@ -66,6 +67,7 @@ public class ConfigClient implements ConfigStore {
     this.options = baseClient.getOptions();
     configLoader = new ConfigLoader(options);
     resolver = new ConfigResolver(baseClient, configLoader);
+    configChangeListeners.add(LoggingConfigListener.getInstance());
 
     if (options.isLocalOnly()) {
       finishInit(Source.LOCAL_ONLY);

--- a/src/main/java/cloud/prefab/client/ConfigClient.java
+++ b/src/main/java/cloud/prefab/client/ConfigClient.java
@@ -24,6 +24,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
@@ -62,12 +63,13 @@ public class ConfigClient implements ConfigStore {
     INIT_TIMEOUT,
   }
 
-  public ConfigClient(PrefabCloudClient baseClient) {
+  public ConfigClient(PrefabCloudClient baseClient, ConfigChangeListener... listeners) {
     this.baseClient = baseClient;
     this.options = baseClient.getOptions();
     configLoader = new ConfigLoader(options);
     resolver = new ConfigResolver(baseClient, configLoader);
     configChangeListeners.add(LoggingConfigListener.getInstance());
+    configChangeListeners.addAll(Arrays.asList(listeners));
 
     if (options.isLocalOnly()) {
       finishInit(Source.LOCAL_ONLY);

--- a/src/main/java/cloud/prefab/client/config/ConfigLoader.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigLoader.java
@@ -10,8 +10,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -80,14 +78,13 @@ public class ConfigLoader {
   private ImmutableMap<String, Prefab.Config> loadClasspathConfig() {
     ImmutableMap.Builder<String, Prefab.Config> builder = ImmutableMap.builder();
 
-    Path dir = Paths.get(options.getConfigOverrideDir());
     for (String env : options.getAllPrefabEnvs()) {
       final String file = String.format(".prefab.%s.config.yaml", env);
 
       try (
         InputStream resourceAsStream = this.getClass()
           .getClassLoader()
-          .getResourceAsStream(dir.resolve(file).toString())
+          .getResourceAsStream(file)
       ) {
         if (resourceAsStream == null) {
           LOG.warn("No default config file found {}", file);

--- a/src/main/java/cloud/prefab/client/config/ConfigLoader.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigLoader.java
@@ -1,13 +1,17 @@
 package cloud.prefab.client.config;
 
 import cloud.prefab.client.Options;
+import cloud.prefab.client.config.logging.AbstractLoggingListener;
 import cloud.prefab.domain.Prefab;
 import cloud.prefab.domain.Prefab.Config;
+import cloud.prefab.domain.Prefab.LogLevel;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -76,21 +80,29 @@ public class ConfigLoader {
   private ImmutableMap<String, Prefab.Config> loadClasspathConfig() {
     ImmutableMap.Builder<String, Prefab.Config> builder = ImmutableMap.builder();
 
+    Path dir = Paths.get(options.getConfigOverrideDir());
     for (String env : options.getAllPrefabEnvs()) {
       final String file = String.format(".prefab.%s.config.yaml", env);
-      final InputStream resourceAsStream =
-        this.getClass().getClassLoader().getResourceAsStream(file);
-      if (resourceAsStream == null) {
-        LOG.warn("No default config file found {}", file);
-      } else {
-        loadFileTo(resourceAsStream, builder, file);
+
+      try (
+        InputStream resourceAsStream = this.getClass()
+          .getClassLoader()
+          .getResourceAsStream(dir.resolve(file).toString())
+      ) {
+        if (resourceAsStream == null) {
+          LOG.warn("No default config file found {}", file);
+        } else {
+          loadFileTo(resourceAsStream, builder, file);
+        }
+      } catch (IOException e) {
+        throw new RuntimeException("Error loading config from file: " + file, e);
       }
     }
 
     return builder.buildKeepingLast();
   }
 
-  private Prefab.Config toValue(Object obj) {
+  private Prefab.Config toValue(String key, Object obj) {
     final Prefab.ConfigValue.Builder builder = Prefab.ConfigValue.newBuilder();
     if (obj instanceof Boolean) {
       builder.setBool((Boolean) obj);
@@ -99,7 +111,11 @@ public class ConfigLoader {
     } else if (obj instanceof Double) {
       builder.setDouble((Double) obj);
     } else if (obj instanceof String) {
-      builder.setString((String) obj);
+      if (AbstractLoggingListener.keyIsLogLevel(key)) {
+        builder.setLogLevel(LogLevel.valueOf((String) obj));
+      } else {
+        builder.setString((String) obj);
+      }
     }
     return Prefab.Config
       .newBuilder()
@@ -137,7 +153,7 @@ public class ConfigLoader {
     Map<String, Object> obj = yaml.load(inputStream);
     obj.forEach((k, v) -> {
       loadKeyValue(k, v, builder);
-      builder.put(k, toValue(v));
+      builder.put(k, toValue(k, v));
     });
   }
 
@@ -157,7 +173,7 @@ public class ConfigLoader {
         loadKeyValue(nestedKey, nest.getValue(), builder);
       }
     } else {
-      builder.put(k, toValue(v));
+      builder.put(k, toValue(k, v));
     }
   }
 

--- a/src/main/java/cloud/prefab/client/config/LoggingConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/LoggingConfigListener.java
@@ -1,0 +1,40 @@
+package cloud.prefab.client.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggingConfigListener implements ConfigChangeListener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingConfigListener.class);
+  private static final ConfigChangeListener INSTANCE = new LoggingConfigListener();
+
+  public static ConfigChangeListener getInstance() {
+    return INSTANCE;
+  }
+
+  private LoggingConfigListener() {}
+
+  @Override
+  public void onChange(ConfigChangeEvent changeEvent) {
+    if (changeEvent.getNewValue().isEmpty()) {
+      LOG.info(
+        "Config value '{}' removed. Previous value was '{}'",
+        changeEvent.getKey(),
+        changeEvent.getOldValue().get()
+      );
+    } else if (changeEvent.getOldValue().isEmpty()) {
+      LOG.info(
+        "Config value '{}' added. New value is '{}'",
+        changeEvent.getKey(),
+        changeEvent.getNewValue().get()
+      );
+    } else {
+      LOG.info(
+        "Config value '{}' updated. Previous value was '{}', new value is '{}'",
+        changeEvent.getKey(),
+        changeEvent.getOldValue().get(),
+        changeEvent.getNewValue().get()
+      );
+    }
+  }
+}

--- a/src/main/java/cloud/prefab/client/config/LoggingConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/LoggingConfigListener.java
@@ -1,5 +1,8 @@
 package cloud.prefab.client.config;
 
+import cloud.prefab.domain.Prefab.ConfigValue;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,21 +23,29 @@ public class LoggingConfigListener implements ConfigChangeListener {
       LOG.info(
         "Config value '{}' removed. Previous value was '{}'",
         changeEvent.getKey(),
-        changeEvent.getOldValue().get()
+        toJson(changeEvent.getOldValue().get())
       );
     } else if (changeEvent.getOldValue().isEmpty()) {
       LOG.info(
         "Config value '{}' added. New value is '{}'",
         changeEvent.getKey(),
-        changeEvent.getNewValue().get()
+        toJson(changeEvent.getNewValue().get())
       );
     } else {
       LOG.info(
         "Config value '{}' updated. Previous value was '{}', new value is '{}'",
         changeEvent.getKey(),
-        changeEvent.getOldValue().get(),
-        changeEvent.getNewValue().get()
+        toJson(changeEvent.getOldValue().get()),
+        toJson(changeEvent.getNewValue().get())
       );
+    }
+  }
+
+  private static String toJson(ConfigValue configValue) {
+    try {
+      return JsonFormat.printer().omittingInsignificantWhitespace().print(configValue);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException("Error writing config value to json", e);
     }
   }
 }

--- a/src/main/java/cloud/prefab/client/config/logging/AbstractLoggingListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/AbstractLoggingListener.java
@@ -2,9 +2,10 @@ package cloud.prefab.client.config.logging;
 
 import cloud.prefab.client.config.ConfigChangeEvent;
 import cloud.prefab.client.config.ConfigChangeListener;
-import cloud.prefab.domain.Prefab;
+import cloud.prefab.domain.Prefab.ConfigValue;
+import cloud.prefab.domain.Prefab.ConfigValue.TypeCase;
+import cloud.prefab.domain.Prefab.LogLevel;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,12 +13,12 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractLoggingListener<LEVEL_TYPE>
   implements ConfigChangeListener {
 
-  private static final String LOG_LEVEL_PREFIX = "log_level.";
+  private static final String LOG_LEVEL_PREFIX = "log-level.";
   private static final String DEFAULT_LOG_LEVEL = LOG_LEVEL_PREFIX + "default";
 
   protected final Logger LOG = LoggerFactory.getLogger(getClass());
 
-  protected abstract Map<String, LEVEL_TYPE> getValidLevels();
+  protected abstract Map<LogLevel, LEVEL_TYPE> getValidLevels();
 
   protected abstract void setDefaultLevel(Optional<LEVEL_TYPE> level);
 
@@ -25,53 +26,43 @@ public abstract class AbstractLoggingListener<LEVEL_TYPE>
 
   @Override
   public final void onChange(ConfigChangeEvent changeEvent) {
-    String key = changeEvent.getKey();
+    if (isLogLevelChange(changeEvent)) {
+      Optional<LEVEL_TYPE> level = changeEvent
+        .getNewValue()
+        .filter(this::isLogLevel)
+        .map(newValue -> getValidLevels().get(newValue.getLogLevel()));
 
-    if (key.startsWith(LOG_LEVEL_PREFIX)) {
-      Optional<Prefab.ConfigValue> newValue = changeEvent.getNewValue();
+      String key = changeEvent.getKey();
+      if (key.equals(DEFAULT_LOG_LEVEL)) {
+        setDefaultLevel(level);
+      } else if (key.startsWith(LOG_LEVEL_PREFIX)) {
+        String loggerName = key.substring(LOG_LEVEL_PREFIX.length());
 
-      if (newValue.isPresent() && !newValue.get().hasString()) {
-        LOG.warn(
-          "Unable to change log level for '{}' because value not a string: '{}'",
-          key,
-          newValue.get()
-        );
+        setLevel(loggerName, level);
       } else {
-        Optional<String> levelName = newValue.map(Prefab.ConfigValue::getString);
-        final Optional<LEVEL_TYPE> level;
-        if (levelName.isPresent()) {
-          level = toLevel(levelName.get());
-          if (level.isEmpty()) {
-            LOG.warn(
-              "Unable to change log level for '{}' because log level is invalid: '{}'",
-              key,
-              levelName.get()
-            );
-          }
-        } else {
-          level = Optional.empty();
-        }
-
-        if (key.equals(DEFAULT_LOG_LEVEL)) {
-          setDefaultLevel(level);
-        } else {
-          String loggerName = key.substring(LOG_LEVEL_PREFIX.length());
-
-          setLevel(loggerName, level);
-        }
+        LOG.warn(
+          "Expected log level override to start with '{}', but was '{}'",
+          LOG_LEVEL_PREFIX,
+          key
+        );
       }
     }
   }
 
-  private Optional<LEVEL_TYPE> toLevel(String levelName) {
-    levelName = levelName.trim();
+  private boolean isLogLevelChange(ConfigChangeEvent changeEvent) {
+    boolean newValueIsLogLevel = changeEvent
+      .getNewValue()
+      .map(this::isLogLevel)
+      .orElse(false);
+    boolean oldValueIsLogLevel = changeEvent
+      .getOldValue()
+      .map(this::isLogLevel)
+      .orElse(false);
 
-    for (Entry<String, LEVEL_TYPE> levelEntry : getValidLevels().entrySet()) {
-      if (levelEntry.getKey().equalsIgnoreCase(levelName)) {
-        return Optional.of(levelEntry.getValue());
-      }
-    }
+    return newValueIsLogLevel || oldValueIsLogLevel;
+  }
 
-    return Optional.empty();
+  private boolean isLogLevel(ConfigValue value) {
+    return TypeCase.LOG_LEVEL.equals(value.getTypeCase());
   }
 }

--- a/src/main/java/cloud/prefab/client/config/logging/AbstractLoggingListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/AbstractLoggingListener.java
@@ -24,6 +24,10 @@ public abstract class AbstractLoggingListener<LEVEL_TYPE>
 
   protected abstract void setLevel(String loggerName, Optional<LEVEL_TYPE> level);
 
+  public static boolean keyIsLogLevel(String key) {
+    return key.startsWith(LOG_LEVEL_PREFIX);
+  }
+
   @Override
   public final void onChange(ConfigChangeEvent changeEvent) {
     if (isLogLevelChange(changeEvent)) {
@@ -35,10 +39,14 @@ public abstract class AbstractLoggingListener<LEVEL_TYPE>
       String key = changeEvent.getKey();
       if (key.equals(DEFAULT_LOG_LEVEL)) {
         setDefaultLevel(level);
-      } else if (key.startsWith(LOG_LEVEL_PREFIX)) {
+
+        LOG.info("Set default log level to '{}'", level.orElse(null));
+      } else if (keyIsLogLevel(key)) {
         String loggerName = key.substring(LOG_LEVEL_PREFIX.length());
 
         setLevel(loggerName, level);
+
+        LOG.info("Set log level for '{}' to '{}'", loggerName, level.orElse(null));
       } else {
         LOG.warn(
           "Expected log level override to start with '{}', but was '{}'",

--- a/src/main/java/cloud/prefab/client/config/logging/AbstractLoggingListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/AbstractLoggingListener.java
@@ -1,0 +1,77 @@
+package cloud.prefab.client.config.logging;
+
+import cloud.prefab.client.config.ConfigChangeEvent;
+import cloud.prefab.client.config.ConfigChangeListener;
+import cloud.prefab.domain.Prefab;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractLoggingListener<LEVEL_TYPE>
+  implements ConfigChangeListener {
+
+  private static final String LOG_LEVEL_PREFIX = "log_level.";
+  private static final String DEFAULT_LOG_LEVEL = LOG_LEVEL_PREFIX + "default";
+
+  protected final Logger LOG = LoggerFactory.getLogger(getClass());
+
+  protected abstract Map<String, LEVEL_TYPE> getValidLevels();
+
+  protected abstract void setDefaultLevel(Optional<LEVEL_TYPE> level);
+
+  protected abstract void setLevel(String loggerName, Optional<LEVEL_TYPE> level);
+
+  @Override
+  public final void onChange(ConfigChangeEvent changeEvent) {
+    String key = changeEvent.getKey();
+
+    if (key.startsWith(LOG_LEVEL_PREFIX)) {
+      Optional<Prefab.ConfigValue> newValue = changeEvent.getNewValue();
+
+      if (newValue.isPresent() && !newValue.get().hasString()) {
+        LOG.warn(
+          "Unable to change log level for '{}' because value not a string: '{}'",
+          key,
+          newValue.get()
+        );
+      } else {
+        Optional<String> levelName = newValue.map(Prefab.ConfigValue::getString);
+        final Optional<LEVEL_TYPE> level;
+        if (levelName.isPresent()) {
+          level = toLevel(levelName.get());
+          if (level.isEmpty()) {
+            LOG.warn(
+              "Unable to change log level for '{}' because log level is invalid: '{}'",
+              key,
+              levelName.get()
+            );
+          }
+        } else {
+          level = Optional.empty();
+        }
+
+        if (key.equals(DEFAULT_LOG_LEVEL)) {
+          setDefaultLevel(level);
+        } else {
+          String loggerName = key.substring(LOG_LEVEL_PREFIX.length());
+
+          setLevel(loggerName, level);
+        }
+      }
+    }
+  }
+
+  private Optional<LEVEL_TYPE> toLevel(String levelName) {
+    levelName = levelName.trim();
+
+    for (Entry<String, LEVEL_TYPE> levelEntry : getValidLevels().entrySet()) {
+      if (levelEntry.getKey().equalsIgnoreCase(levelName)) {
+        return Optional.of(levelEntry.getValue());
+      }
+    }
+
+    return Optional.empty();
+  }
+}

--- a/src/main/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListener.java
@@ -1,0 +1,52 @@
+package cloud.prefab.client.config.logging;
+
+import cloud.prefab.client.config.ConfigChangeListener;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+public class JavaUtilLoggingConfigListener extends AbstractLoggingListener<Level> {
+
+  private static final ConfigChangeListener INSTANCE = new JavaUtilLoggingConfigListener();
+
+  private static final String ROOT_LOGGER = "";
+
+  private static final Map<String, Level> LEVEL_MAP = ImmutableMap
+    .<String, Level>builder()
+    .put("OFF", Level.OFF)
+    .put("SEVERE", Level.SEVERE)
+    .put("WARNING", Level.WARNING)
+    .put("INFO", Level.INFO)
+    .put("CONFIG", Level.CONFIG)
+    .put("FINE", Level.FINE)
+    .put("FINER", Level.FINER)
+    .put("FINEST", Level.FINEST)
+    .put("ALL", Level.ALL)
+    .build();
+
+  public static ConfigChangeListener getInstance() {
+    return INSTANCE;
+  }
+
+  private JavaUtilLoggingConfigListener() {}
+
+  @Override
+  protected Map<String, Level> getValidLevels() {
+    return LEVEL_MAP;
+  }
+
+  @Override
+  protected void setDefaultLevel(Optional<Level> level) {
+    setLevel(ROOT_LOGGER, level);
+  }
+
+  @Override
+  protected void setLevel(String loggerName, Optional<Level> level) {
+    Logger logger = LogManager.getLogManager().getLogger(loggerName);
+
+    logger.setLevel(level.orElse(null));
+  }
+}

--- a/src/main/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListener.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 /**
@@ -53,7 +52,7 @@ public class JavaUtilLoggingConfigListener extends AbstractLoggingListener<Level
 
   @Override
   protected void setLevel(String loggerName, Optional<Level> level) {
-    Logger logger = LogManager.getLogManager().getLogger(loggerName);
+    Logger logger = Logger.getLogger(loggerName);
 
     logger.setLevel(level.orElse(null));
   }

--- a/src/main/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListener.java
@@ -9,13 +9,22 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
+/**
+ * Log levels require some translation:
+ * - FATAL -> SEVERE
+ * - ERROR -> SEVERE
+ * - WARN -> WARNING
+ * - DEBUG -> FINE
+ * - TRACE -> FINER
+ * <p>
+ * OFF, CONFIG, FINEST, and ALL are unsupported
+ */
 public class JavaUtilLoggingConfigListener extends AbstractLoggingListener<Level> {
 
   private static final ConfigChangeListener INSTANCE = new JavaUtilLoggingConfigListener();
 
   private static final String ROOT_LOGGER = "";
 
-  // missing OFF, CONFIG, FINEST, and ALL
   private static final Map<LogLevel, Level> LEVEL_MAP = ImmutableMap
     .<LogLevel, Level>builder()
     .put(LogLevel.FATAL, Level.SEVERE)

--- a/src/main/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListener.java
@@ -1,6 +1,7 @@
 package cloud.prefab.client.config.logging;
 
 import cloud.prefab.client.config.ConfigChangeListener;
+import cloud.prefab.domain.Prefab.LogLevel;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
@@ -14,17 +15,15 @@ public class JavaUtilLoggingConfigListener extends AbstractLoggingListener<Level
 
   private static final String ROOT_LOGGER = "";
 
-  private static final Map<String, Level> LEVEL_MAP = ImmutableMap
-    .<String, Level>builder()
-    .put("OFF", Level.OFF)
-    .put("SEVERE", Level.SEVERE)
-    .put("WARNING", Level.WARNING)
-    .put("INFO", Level.INFO)
-    .put("CONFIG", Level.CONFIG)
-    .put("FINE", Level.FINE)
-    .put("FINER", Level.FINER)
-    .put("FINEST", Level.FINEST)
-    .put("ALL", Level.ALL)
+  // missing OFF, CONFIG, FINEST, and ALL
+  private static final Map<LogLevel, Level> LEVEL_MAP = ImmutableMap
+    .<LogLevel, Level>builder()
+    .put(LogLevel.FATAL, Level.SEVERE)
+    .put(LogLevel.ERROR, Level.SEVERE)
+    .put(LogLevel.WARN, Level.WARNING)
+    .put(LogLevel.INFO, Level.INFO)
+    .put(LogLevel.DEBUG, Level.FINE)
+    .put(LogLevel.TRACE, Level.FINER)
     .build();
 
   public static ConfigChangeListener getInstance() {
@@ -34,7 +33,7 @@ public class JavaUtilLoggingConfigListener extends AbstractLoggingListener<Level
   private JavaUtilLoggingConfigListener() {}
 
   @Override
-  protected Map<String, Level> getValidLevels() {
+  protected Map<LogLevel, Level> getValidLevels() {
     return LEVEL_MAP;
   }
 

--- a/src/main/java/cloud/prefab/client/config/logging/Log4j1ConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/Log4j1ConfigListener.java
@@ -8,11 +8,13 @@ import java.util.Optional;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 
+/**
+ * OFF and ALL log levels are unsupported
+ */
 public class Log4j1ConfigListener extends AbstractLoggingListener<Level> {
 
   private static final ConfigChangeListener INSTANCE = new Log4j1ConfigListener();
 
-  // missing OFF and ALL
   private static final Map<LogLevel, Level> LEVEL_MAP = ImmutableMap
     .<LogLevel, Level>builder()
     .put(LogLevel.FATAL, Level.FATAL)

--- a/src/main/java/cloud/prefab/client/config/logging/Log4j1ConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/Log4j1ConfigListener.java
@@ -1,6 +1,7 @@
 package cloud.prefab.client.config.logging;
 
 import cloud.prefab.client.config.ConfigChangeListener;
+import cloud.prefab.domain.Prefab.LogLevel;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
@@ -11,16 +12,15 @@ public class Log4j1ConfigListener extends AbstractLoggingListener<Level> {
 
   private static final ConfigChangeListener INSTANCE = new Log4j1ConfigListener();
 
-  private static final Map<String, Level> LEVEL_MAP = ImmutableMap
-    .<String, Level>builder()
-    .put("OFF", Level.OFF)
-    .put("FATAL", Level.FATAL)
-    .put("ERROR", Level.ERROR)
-    .put("WARN", Level.WARN)
-    .put("INFO", Level.INFO)
-    .put("DEBUG", Level.DEBUG)
-    .put("TRACE", Level.TRACE)
-    .put("ALL", Level.ALL)
+  // missing OFF and ALL
+  private static final Map<LogLevel, Level> LEVEL_MAP = ImmutableMap
+    .<LogLevel, Level>builder()
+    .put(LogLevel.FATAL, Level.FATAL)
+    .put(LogLevel.ERROR, Level.ERROR)
+    .put(LogLevel.WARN, Level.WARN)
+    .put(LogLevel.INFO, Level.INFO)
+    .put(LogLevel.DEBUG, Level.DEBUG)
+    .put(LogLevel.TRACE, Level.TRACE)
     .build();
 
   public static ConfigChangeListener getInstance() {
@@ -30,7 +30,7 @@ public class Log4j1ConfigListener extends AbstractLoggingListener<Level> {
   private Log4j1ConfigListener() {}
 
   @Override
-  protected Map<String, Level> getValidLevels() {
+  protected Map<LogLevel, Level> getValidLevels() {
     return LEVEL_MAP;
   }
 

--- a/src/main/java/cloud/prefab/client/config/logging/Log4j1ConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/Log4j1ConfigListener.java
@@ -1,0 +1,46 @@
+package cloud.prefab.client.config.logging;
+
+import cloud.prefab.client.config.ConfigChangeListener;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+
+public class Log4j1ConfigListener extends AbstractLoggingListener<Level> {
+
+  private static final ConfigChangeListener INSTANCE = new Log4j1ConfigListener();
+
+  private static final Map<String, Level> LEVEL_MAP = ImmutableMap
+    .<String, Level>builder()
+    .put("OFF", Level.OFF)
+    .put("FATAL", Level.FATAL)
+    .put("ERROR", Level.ERROR)
+    .put("WARN", Level.WARN)
+    .put("INFO", Level.INFO)
+    .put("DEBUG", Level.DEBUG)
+    .put("TRACE", Level.TRACE)
+    .put("ALL", Level.ALL)
+    .build();
+
+  public static ConfigChangeListener getInstance() {
+    return INSTANCE;
+  }
+
+  private Log4j1ConfigListener() {}
+
+  @Override
+  protected Map<String, Level> getValidLevels() {
+    return LEVEL_MAP;
+  }
+
+  @Override
+  protected void setDefaultLevel(Optional<Level> level) {
+    LogManager.getRootLogger().setLevel(level.orElse(null));
+  }
+
+  @Override
+  protected void setLevel(String loggerName, Optional<Level> level) {
+    LogManager.getLogger(loggerName).setLevel(level.orElse(null));
+  }
+}

--- a/src/main/java/cloud/prefab/client/config/logging/Log4j2ConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/Log4j2ConfigListener.java
@@ -8,11 +8,13 @@ import java.util.Optional;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 
+/**
+ * OFF and ALL log levels are unsupported
+ */
 public class Log4j2ConfigListener extends AbstractLoggingListener<Level> {
 
   private static final ConfigChangeListener INSTANCE = new Log4j2ConfigListener();
 
-  // missing OFF and ALL
   private static final Map<LogLevel, Level> LEVEL_MAP = ImmutableMap
     .<LogLevel, Level>builder()
     .put(LogLevel.FATAL, Level.FATAL)

--- a/src/main/java/cloud/prefab/client/config/logging/Log4j2ConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/Log4j2ConfigListener.java
@@ -1,0 +1,46 @@
+package cloud.prefab.client.config.logging;
+
+import cloud.prefab.client.config.ConfigChangeListener;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+
+public class Log4j2ConfigListener extends AbstractLoggingListener<Level> {
+
+  private static final ConfigChangeListener INSTANCE = new Log4j2ConfigListener();
+
+  private static final Map<String, Level> LEVEL_MAP = ImmutableMap
+    .<String, Level>builder()
+    .put("OFF", Level.OFF)
+    .put("FATAL", Level.FATAL)
+    .put("ERROR", Level.ERROR)
+    .put("WARN", Level.WARN)
+    .put("INFO", Level.INFO)
+    .put("DEBUG", Level.DEBUG)
+    .put("TRACE", Level.TRACE)
+    .put("ALL", Level.ALL)
+    .build();
+
+  public static ConfigChangeListener getInstance() {
+    return INSTANCE;
+  }
+
+  private Log4j2ConfigListener() {}
+
+  @Override
+  protected Map<String, Level> getValidLevels() {
+    return LEVEL_MAP;
+  }
+
+  @Override
+  protected void setDefaultLevel(Optional<Level> level) {
+    Configurator.setRootLevel(level.orElse(null));
+  }
+
+  @Override
+  protected void setLevel(String loggerName, Optional<Level> level) {
+    Configurator.setLevel(loggerName, level.orElse(null));
+  }
+}

--- a/src/main/java/cloud/prefab/client/config/logging/Log4j2ConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/Log4j2ConfigListener.java
@@ -1,6 +1,7 @@
 package cloud.prefab.client.config.logging;
 
 import cloud.prefab.client.config.ConfigChangeListener;
+import cloud.prefab.domain.Prefab.LogLevel;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
@@ -11,16 +12,15 @@ public class Log4j2ConfigListener extends AbstractLoggingListener<Level> {
 
   private static final ConfigChangeListener INSTANCE = new Log4j2ConfigListener();
 
-  private static final Map<String, Level> LEVEL_MAP = ImmutableMap
-    .<String, Level>builder()
-    .put("OFF", Level.OFF)
-    .put("FATAL", Level.FATAL)
-    .put("ERROR", Level.ERROR)
-    .put("WARN", Level.WARN)
-    .put("INFO", Level.INFO)
-    .put("DEBUG", Level.DEBUG)
-    .put("TRACE", Level.TRACE)
-    .put("ALL", Level.ALL)
+  // missing OFF and ALL
+  private static final Map<LogLevel, Level> LEVEL_MAP = ImmutableMap
+    .<LogLevel, Level>builder()
+    .put(LogLevel.FATAL, Level.FATAL)
+    .put(LogLevel.ERROR, Level.ERROR)
+    .put(LogLevel.WARN, Level.WARN)
+    .put(LogLevel.INFO, Level.INFO)
+    .put(LogLevel.DEBUG, Level.DEBUG)
+    .put(LogLevel.TRACE, Level.TRACE)
     .build();
 
   public static ConfigChangeListener getInstance() {
@@ -30,7 +30,7 @@ public class Log4j2ConfigListener extends AbstractLoggingListener<Level> {
   private Log4j2ConfigListener() {}
 
   @Override
-  protected Map<String, Level> getValidLevels() {
+  protected Map<LogLevel, Level> getValidLevels() {
     return LEVEL_MAP;
   }
 

--- a/src/main/java/cloud/prefab/client/config/logging/LogbackConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/LogbackConfigListener.java
@@ -1,0 +1,56 @@
+package cloud.prefab.client.config.logging;
+
+import ch.qos.logback.classic.Level;
+import cloud.prefab.client.config.ConfigChangeListener;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogbackConfigListener extends AbstractLoggingListener<Level> {
+
+  private static final ConfigChangeListener INSTANCE = new LogbackConfigListener();
+
+  private static final Map<String, Level> LEVEL_MAP = ImmutableMap
+    .<String, Level>builder()
+    .put("OFF", Level.OFF)
+    .put("ERROR", Level.ERROR)
+    .put("WARN", Level.WARN)
+    .put("INFO", Level.INFO)
+    .put("DEBUG", Level.DEBUG)
+    .put("TRACE", Level.TRACE)
+    .put("ALL", Level.ALL)
+    .build();
+
+  public static ConfigChangeListener getInstance() {
+    return INSTANCE;
+  }
+
+  private LogbackConfigListener() {}
+
+  @Override
+  protected Map<String, Level> getValidLevels() {
+    return LEVEL_MAP;
+  }
+
+  @Override
+  protected void setDefaultLevel(Optional<Level> level) {
+    setLevel(Logger.ROOT_LOGGER_NAME, level);
+  }
+
+  @Override
+  protected void setLevel(String loggerName, Optional<Level> level) {
+    Logger logger = LoggerFactory.getLogger(loggerName);
+
+    if (logger instanceof ch.qos.logback.classic.Logger) {
+      ((ch.qos.logback.classic.Logger) logger).setLevel(level.orElse(null));
+    } else {
+      LOG.warn(
+        "Unable to change log level for '{}' because logging implementation is not Logback: '{}'",
+        loggerName,
+        logger.getClass()
+      );
+    }
+  }
+}

--- a/src/main/java/cloud/prefab/client/config/logging/LogbackConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/LogbackConfigListener.java
@@ -2,6 +2,7 @@ package cloud.prefab.client.config.logging;
 
 import ch.qos.logback.classic.Level;
 import cloud.prefab.client.config.ConfigChangeListener;
+import cloud.prefab.domain.Prefab.LogLevel;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
@@ -12,15 +13,15 @@ public class LogbackConfigListener extends AbstractLoggingListener<Level> {
 
   private static final ConfigChangeListener INSTANCE = new LogbackConfigListener();
 
-  private static final Map<String, Level> LEVEL_MAP = ImmutableMap
-    .<String, Level>builder()
-    .put("OFF", Level.OFF)
-    .put("ERROR", Level.ERROR)
-    .put("WARN", Level.WARN)
-    .put("INFO", Level.INFO)
-    .put("DEBUG", Level.DEBUG)
-    .put("TRACE", Level.TRACE)
-    .put("ALL", Level.ALL)
+  // missing OFF and ALL
+  private static final Map<LogLevel, Level> LEVEL_MAP = ImmutableMap
+    .<LogLevel, Level>builder()
+    .put(LogLevel.FATAL, Level.ERROR)
+    .put(LogLevel.ERROR, Level.ERROR)
+    .put(LogLevel.WARN, Level.WARN)
+    .put(LogLevel.INFO, Level.INFO)
+    .put(LogLevel.DEBUG, Level.DEBUG)
+    .put(LogLevel.TRACE, Level.TRACE)
     .build();
 
   public static ConfigChangeListener getInstance() {
@@ -30,7 +31,7 @@ public class LogbackConfigListener extends AbstractLoggingListener<Level> {
   private LogbackConfigListener() {}
 
   @Override
-  protected Map<String, Level> getValidLevels() {
+  protected Map<LogLevel, Level> getValidLevels() {
     return LEVEL_MAP;
   }
 

--- a/src/main/java/cloud/prefab/client/config/logging/LogbackConfigListener.java
+++ b/src/main/java/cloud/prefab/client/config/logging/LogbackConfigListener.java
@@ -9,11 +9,16 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Log levels require some translation:
+ * - FATAL -> ERROR
+ * <p>
+ * OFF and ALL are unsupported
+ */
 public class LogbackConfigListener extends AbstractLoggingListener<Level> {
 
   private static final ConfigChangeListener INSTANCE = new LogbackConfigListener();
 
-  // missing OFF and ALL
   private static final Map<LogLevel, Level> LEVEL_MAP = ImmutableMap
     .<LogLevel, Level>builder()
     .put(LogLevel.FATAL, Level.ERROR)

--- a/src/test/java/cloud/prefab/client/config/ConfigResolverTest.java
+++ b/src/test/java/cloud/prefab/client/config/ConfigResolverTest.java
@@ -236,21 +236,6 @@ public class ConfigResolverTest {
     assertThat(key.get().getString()).isEqualTo(expectedValue);
   }
 
-  private void put(String key, String value, Map<String, Prefab.Config> data) {
-    data.put(
-      key,
-      Prefab.Config
-        .newBuilder()
-        .setKey(key)
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setValue(Prefab.ConfigValue.newBuilder().setString(value).build())
-        )
-        .build()
-    );
-  }
-
   private Map<String, Prefab.Config> testData() {
     Map<String, Prefab.Config> rtn = new HashMap<>();
     rtn.put(

--- a/src/test/java/cloud/prefab/client/config/logging/AbstractLoggingListenerTest.java
+++ b/src/test/java/cloud/prefab/client/config/logging/AbstractLoggingListenerTest.java
@@ -1,0 +1,43 @@
+package cloud.prefab.client.config.logging;
+
+import cloud.prefab.client.Options;
+import cloud.prefab.client.Options.Datasources;
+import cloud.prefab.client.PrefabCloudClient;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class AbstractLoggingListenerTest {
+
+  protected abstract void reset();
+
+  protected String specificLoggerName() {
+    return "test.logger";
+  }
+
+  protected String otherLoggerName() {
+    return "other.logger";
+  }
+
+  protected PrefabCloudClient clientWithSpecificLogLevel() {
+    return new PrefabCloudClient(
+      new Options()
+        .setPrefabDatasource(Datasources.LOCAL_ONLY)
+        .setConfigOverrideDir("override_directory")
+        .setPrefabEnvs(List.of("logging_specific"))
+    );
+  }
+
+  protected PrefabCloudClient clientWithDefaultLogLevel() {
+    return new PrefabCloudClient(
+      new Options()
+        .setPrefabDatasource(Datasources.LOCAL_ONLY)
+        .setConfigOverrideDir("override_directory")
+        .setPrefabEnvs(List.of("logging_default"))
+    );
+  }
+
+  @BeforeEach
+  public void doReset() {
+    reset();
+  }
+}

--- a/src/test/java/cloud/prefab/client/config/logging/AbstractLoggingListenerTest.java
+++ b/src/test/java/cloud/prefab/client/config/logging/AbstractLoggingListenerTest.java
@@ -22,7 +22,7 @@ public abstract class AbstractLoggingListenerTest {
     return new PrefabCloudClient(
       new Options()
         .setPrefabDatasource(Datasources.LOCAL_ONLY)
-        .setConfigOverrideDir("override_directory")
+        .setConfigOverrideDir("src/test/resources/override_directory")
         .setPrefabEnvs(List.of("logging_specific"))
     );
   }
@@ -31,7 +31,7 @@ public abstract class AbstractLoggingListenerTest {
     return new PrefabCloudClient(
       new Options()
         .setPrefabDatasource(Datasources.LOCAL_ONLY)
-        .setConfigOverrideDir("override_directory")
+        .setConfigOverrideDir("src/test/resources/override_directory")
         .setPrefabEnvs(List.of("logging_default"))
     );
   }

--- a/src/test/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListenerTest.java
+++ b/src/test/java/cloud/prefab/client/config/logging/JavaUtilLoggingConfigListenerTest.java
@@ -1,0 +1,45 @@
+package cloud.prefab.client.config.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import cloud.prefab.client.ConfigClient;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+public class JavaUtilLoggingConfigListenerTest extends AbstractLoggingListenerTest {
+
+  @Override
+  protected void reset() {
+    LogManager.getLogManager().reset();
+  }
+
+  @Test
+  public void itSetsSpecificLogLevel() {
+    new ConfigClient(
+      clientWithSpecificLogLevel(),
+      JavaUtilLoggingConfigListener.getInstance()
+    );
+
+    assertThat(Logger.getLogger(specificLoggerName()).isLoggable(Level.WARNING)).isTrue();
+    assertThat(Logger.getLogger(specificLoggerName()).isLoggable(Level.INFO)).isFalse();
+
+    assertThat(Logger.getLogger(otherLoggerName()).isLoggable(Level.WARNING)).isTrue();
+    assertThat(Logger.getLogger(otherLoggerName()).isLoggable(Level.INFO)).isTrue();
+  }
+
+  @Test
+  public void itSetsDefaultLogLevel() {
+    new ConfigClient(
+      clientWithDefaultLogLevel(),
+      JavaUtilLoggingConfigListener.getInstance()
+    );
+
+    assertThat(Logger.getLogger(specificLoggerName()).isLoggable(Level.WARNING)).isTrue();
+    assertThat(Logger.getLogger(specificLoggerName()).isLoggable(Level.INFO)).isFalse();
+
+    assertThat(Logger.getLogger(otherLoggerName()).isLoggable(Level.WARNING)).isTrue();
+    assertThat(Logger.getLogger(otherLoggerName()).isLoggable(Level.INFO)).isFalse();
+  }
+}

--- a/src/test/java/cloud/prefab/client/config/logging/Log4j1ConfigListenerTest.java
+++ b/src/test/java/cloud/prefab/client/config/logging/Log4j1ConfigListenerTest.java
@@ -1,0 +1,38 @@
+package cloud.prefab.client.config.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import cloud.prefab.client.ConfigClient;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.junit.jupiter.api.Test;
+
+public class Log4j1ConfigListenerTest extends AbstractLoggingListenerTest {
+
+  @Override
+  protected void reset() {
+    LogManager.resetConfiguration();
+  }
+
+  @Test
+  public void itSetsSpecificLogLevel() {
+    new ConfigClient(clientWithSpecificLogLevel(), Log4j1ConfigListener.getInstance());
+
+    assertThat(LogManager.getLogger(specificLoggerName()).getEffectiveLevel())
+      .isEqualTo(Level.WARN);
+
+    assertThat(LogManager.getLogger(otherLoggerName()).getEffectiveLevel())
+      .isEqualTo(Level.DEBUG);
+  }
+
+  @Test
+  public void itSetsDefaultLogLevel() {
+    new ConfigClient(clientWithDefaultLogLevel(), Log4j1ConfigListener.getInstance());
+
+    assertThat(LogManager.getLogger(specificLoggerName()).getEffectiveLevel())
+      .isEqualTo(Level.WARN);
+
+    assertThat(LogManager.getLogger(otherLoggerName()).getEffectiveLevel())
+      .isEqualTo(Level.WARN);
+  }
+}

--- a/src/test/java/cloud/prefab/client/config/logging/Log4j2ConfigListenerTest.java
+++ b/src/test/java/cloud/prefab/client/config/logging/Log4j2ConfigListenerTest.java
@@ -1,0 +1,37 @@
+package cloud.prefab.client.config.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import cloud.prefab.client.ConfigClient;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.Test;
+
+public class Log4j2ConfigListenerTest extends AbstractLoggingListenerTest {
+
+  @Override
+  protected void reset() {
+    Configurator.reconfigure();
+  }
+
+  @Test
+  public void itSetsSpecificLogLevel() {
+    new ConfigClient(clientWithSpecificLogLevel(), Log4j2ConfigListener.getInstance());
+
+    assertThat(LogManager.getLogger(specificLoggerName()).getLevel())
+      .isEqualTo(Level.WARN);
+
+    assertThat(LogManager.getLogger(otherLoggerName()).getLevel()).isEqualTo(Level.ERROR);
+  }
+
+  @Test
+  public void itSetsDefaultLogLevel() {
+    new ConfigClient(clientWithDefaultLogLevel(), Log4j2ConfigListener.getInstance());
+
+    assertThat(LogManager.getLogger(specificLoggerName()).getLevel())
+      .isEqualTo(Level.WARN);
+
+    assertThat(LogManager.getLogger(otherLoggerName()).getLevel()).isEqualTo(Level.WARN);
+  }
+}

--- a/src/test/java/cloud/prefab/client/config/logging/LogbackConfigListenerTest.java
+++ b/src/test/java/cloud/prefab/client/config/logging/LogbackConfigListenerTest.java
@@ -1,0 +1,44 @@
+package cloud.prefab.client.config.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import cloud.prefab.client.ConfigClient;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+public class LogbackConfigListenerTest extends AbstractLoggingListenerTest {
+
+  @Override
+  protected void reset() {
+    ((LoggerContext) LoggerFactory.getILoggerFactory()).reset();
+  }
+
+  @Test
+  public void itSetsSpecificLogLevel() {
+    new ConfigClient(clientWithSpecificLogLevel(), LogbackConfigListener.getInstance());
+
+    assertThat(
+      ((Logger) LoggerFactory.getLogger(specificLoggerName())).getEffectiveLevel()
+    )
+      .isEqualTo(Level.WARN);
+
+    assertThat(((Logger) LoggerFactory.getLogger(otherLoggerName())).getEffectiveLevel())
+      .isEqualTo(Level.DEBUG);
+  }
+
+  @Test
+  public void itSetsDefaultLogLevel() {
+    new ConfigClient(clientWithDefaultLogLevel(), LogbackConfigListener.getInstance());
+
+    assertThat(
+      ((Logger) LoggerFactory.getLogger(specificLoggerName())).getEffectiveLevel()
+    )
+      .isEqualTo(Level.WARN);
+
+    assertThat(((Logger) LoggerFactory.getLogger(otherLoggerName())).getEffectiveLevel())
+      .isEqualTo(Level.WARN);
+  }
+}

--- a/src/test/resources/override_directory/.prefab.logging_default.config.yaml
+++ b/src/test/resources/override_directory/.prefab.logging_default.config.yaml
@@ -1,0 +1,1 @@
+log-level.default: WARN

--- a/src/test/resources/override_directory/.prefab.logging_specific.config.yaml
+++ b/src/test/resources/override_directory/.prefab.logging_specific.config.yaml
@@ -1,0 +1,1 @@
+log-level.test.logger: WARN


### PR DESCRIPTION
This PR adds logging adapters for java util logging, log4j1, log4j2, and logback that can be used to wire up config values to log levels. It would be up to users to register the correct adapter based on their logging framework

/cc @jdwyah 