### PR TITLE
Jd/provenance

### DIFF
--- a/src/main/java/cloud/prefab/client/ConfigClient.java
+++ b/src/main/java/cloud/prefab/client/ConfigClient.java
@@ -13,7 +13,6 @@ import cloud.prefab.client.value.Value;
 import cloud.prefab.domain.ConfigServiceGrpc;
 import cloud.prefab.domain.Prefab;
 import com.google.common.collect.Sets;
-import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -22,7 +21,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -199,17 +197,8 @@ public class ConfigClient implements ConfigStore {
   }
 
   boolean loadCDN() {
-    final String keyHash = keyHash(options.getApikey());
-    final String url = String.format(
-      "%s/api/v1/configs/0/%s/0",
-      options.getCDNUrl(),
-      keyHash
-    );
+    final String url = String.format("%s/api/v1/configs/0", options.getCDNUrl());
     return loadCheckpointFromUrl(url, Source.REMOTE_CDN);
-  }
-
-  private String keyHash(String apikey) {
-    return Hashing.sha256().hashString(apikey, StandardCharsets.UTF_8).toString();
   }
 
   private static final String getBasicAuthenticationHeader(
@@ -240,7 +229,7 @@ public class ConfigClient implements ConfigStore {
       );
 
       if (response.statusCode() != 200) {
-        LOG.warn("Problem loading CDN {}", response.statusCode());
+        LOG.warn("Problem loading {} {} {}", source, response.statusCode(), url);
       } else {
         Prefab.Configs configs = Prefab.Configs.parseFrom(response.body());
         loadConfigs(configs, source);

--- a/src/main/java/cloud/prefab/client/ConfigClient.java
+++ b/src/main/java/cloud/prefab/client/ConfigClient.java
@@ -2,6 +2,7 @@ package cloud.prefab.client;
 
 import cloud.prefab.client.config.ConfigChangeEvent;
 import cloud.prefab.client.config.ConfigChangeListener;
+import cloud.prefab.client.config.ConfigElement;
 import cloud.prefab.client.config.ConfigLoader;
 import cloud.prefab.client.config.ConfigResolver;
 import cloud.prefab.client.config.LoggingConfigListener;
@@ -53,12 +54,14 @@ public class ConfigClient implements ConfigStore {
   private final CountDownLatch initializedLatch = new CountDownLatch(1);
   private final Set<ConfigChangeListener> configChangeListeners = Sets.newConcurrentHashSet();
 
-  private enum Source {
+  public enum Source {
     REMOTE_API_GRPC,
     STREAMING,
     REMOTE_CDN,
     LOCAL_ONLY,
     INIT_TIMEOUT,
+    CLASSPATH,
+    OVERRIDE,
   }
 
   public ConfigClient(PrefabCloudClient baseClient, ConfigChangeListener... listeners) {
@@ -336,7 +339,7 @@ public class ConfigClient implements ConfigStore {
     final long startingHighWaterMark = configLoader.getHighwaterMark();
 
     for (Prefab.Config config : configs.getConfigsList()) {
-      configLoader.set(config);
+      configLoader.set(new ConfigElement(config, source, ""));
     }
 
     if (configLoader.getHighwaterMark() > startingHighWaterMark) {

--- a/src/main/java/cloud/prefab/client/config/ConfigElement.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigElement.java
@@ -1,0 +1,33 @@
+package cloud.prefab.client.config;
+
+import cloud.prefab.client.ConfigClient;
+import cloud.prefab.domain.Prefab;
+
+public class ConfigElement {
+
+  private Prefab.Config config;
+  private ConfigClient.Source source;
+  private String sourceLocation;
+
+  public ConfigElement(
+    Prefab.Config config,
+    ConfigClient.Source source,
+    String sourceLocation
+  ) {
+    this.config = config;
+    this.source = source;
+    this.sourceLocation = sourceLocation;
+  }
+
+  public Prefab.Config getConfig() {
+    return config;
+  }
+
+  public ConfigClient.Source getSource() {
+    return source;
+  }
+
+  public String getSourceLocation() {
+    return sourceLocation;
+  }
+}

--- a/src/main/java/cloud/prefab/client/config/ConfigResolver.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigResolver.java
@@ -9,6 +9,7 @@ import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -159,7 +160,7 @@ public class ConfigResolver {
                     1,
                     configElement,
                     row.getValue(),
-                    String.format("%d", projectEnvId)
+                    String.format("Env:%d", projectEnvId)
                   );
                 }
               } else {
@@ -205,11 +206,13 @@ public class ConfigResolver {
 
   public String contentsString() {
     StringBuilder sb = new StringBuilder("\n");
-
-    for (Map.Entry<String, ResolverElement> entry : localMap.get().entrySet()) {
-      sb.append(padded(entry.getKey(), 30));
-      sb.append(padded(toS(entry.getValue().getConfigValue()), 40));
-      sb.append(padded(entry.getValue().provenance(), 90));
+    List<String> sortedKeys = new ArrayList(localMap.get().keySet());
+    Collections.sort(sortedKeys);
+    for (String key : sortedKeys) {
+      ResolverElement resolverElement = localMap.get().get(key);
+      sb.append(padded(key, 30));
+      sb.append(padded(toS(resolverElement.getConfigValue()), 40));
+      sb.append(padded(resolverElement.provenance(), 90));
       sb.append("\n");
     }
     System.out.println(sb.toString());

--- a/src/main/java/cloud/prefab/client/config/ConfigResolver.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigResolver.java
@@ -228,7 +228,9 @@ public class ConfigResolver {
     } else if (configValue.getTypeCase() == Prefab.ConfigValue.TypeCase.SEGMENT) {
       return "Segment";
     } else if (configValue.getTypeCase() == Prefab.ConfigValue.TypeCase.FEATURE_FLAG) {
-      return "FeatureFlage";
+      return "FeatureFlag";
+    } else if (configValue.getTypeCase() == Prefab.ConfigValue.TypeCase.LOG_LEVEL) {
+      return configValue.getLogLevel().toString();
     } else {
       return "Unknown";
     }

--- a/src/main/java/cloud/prefab/client/config/ConfigResolver.java
+++ b/src/main/java/cloud/prefab/client/config/ConfigResolver.java
@@ -129,8 +129,9 @@ public class ConfigResolver {
 
     configLoader
       .calcConfig()
-      .forEach((key, config) -> {
-        List<ResolverElement> l = config
+      .forEach((key, configElement) -> {
+        List<ResolverElement> l = configElement
+          .getConfig()
           .getRowsList()
           .stream()
           .map(row -> {
@@ -146,7 +147,7 @@ public class ConfigResolver {
                   if (match.isMatch()) {
                     return new ResolverElement(
                       2 + match.getPartCount(),
-                      config,
+                      configElement,
                       row.getValue(),
                       row.getNamespace()
                     );
@@ -156,7 +157,7 @@ public class ConfigResolver {
                 } else {
                   return new ResolverElement(
                     1,
-                    config,
+                    configElement,
                     row.getValue(),
                     String.format("%d", projectEnvId)
                   );
@@ -165,7 +166,7 @@ public class ConfigResolver {
                 return null;
               }
             }
-            return new ResolverElement(0, config, row.getValue(), "default");
+            return new ResolverElement(0, configElement, row.getValue(), "default");
           })
           .filter(Objects::nonNull)
           .sorted()
@@ -207,7 +208,8 @@ public class ConfigResolver {
 
     for (Map.Entry<String, ResolverElement> entry : localMap.get().entrySet()) {
       sb.append(padded(entry.getKey(), 30));
-      sb.append(padded(toS(entry.getValue().getConfigValue()), 90));
+      sb.append(padded(toS(entry.getValue().getConfigValue()), 40));
+      sb.append(padded(entry.getValue().provenance(), 90));
       sb.append("\n");
     }
     System.out.println(sb.toString());

--- a/src/main/java/cloud/prefab/client/config/ResolverElement.java
+++ b/src/main/java/cloud/prefab/client/config/ResolverElement.java
@@ -42,11 +42,12 @@ public class ResolverElement implements Comparable<ResolverElement> {
   }
 
   public String provenance() {
-    return MoreObjects
-      .toStringHelper(this)
-      .add("source", configElement.getSource())
-      .add("sourceLocation", configElement.getSourceLocation())
-      .add("match", match)
+    return new StringBuilder()
+      .append(configElement.getSource().name())
+      .append(":")
+      .append(configElement.getSourceLocation())
+      .append(":")
+      .append(match)
       .toString();
   }
 

--- a/src/main/java/cloud/prefab/client/config/ResolverElement.java
+++ b/src/main/java/cloud/prefab/client/config/ResolverElement.java
@@ -1,5 +1,6 @@
 package cloud.prefab.client.config;
 
+import cloud.prefab.client.ConfigClient;
 import cloud.prefab.domain.Prefab;
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
@@ -7,18 +8,18 @@ import java.util.Objects;
 public class ResolverElement implements Comparable<ResolverElement> {
 
   private final int matchSize;
-  private final Prefab.Config config;
+  private final ConfigElement configElement;
   private final Prefab.ConfigValue configValue;
   private final String match;
 
   public ResolverElement(
     int matchSize,
-    Prefab.Config config,
+    ConfigElement configElement,
     Prefab.ConfigValue configValue,
     String match
   ) {
     this.matchSize = matchSize;
-    this.config = config;
+    this.configElement = configElement;
     this.configValue = configValue;
     this.match = match;
   }
@@ -33,11 +34,20 @@ public class ResolverElement implements Comparable<ResolverElement> {
   }
 
   public Prefab.Config getConfig() {
-    return config;
+    return configElement.getConfig();
   }
 
   public int getMatchSize() {
     return matchSize;
+  }
+
+  public String provenance() {
+    return MoreObjects
+      .toStringHelper(this)
+      .add("source", configElement.getSource())
+      .add("sourceLocation", configElement.getSourceLocation())
+      .add("match", match)
+      .toString();
   }
 
   @Override
@@ -45,7 +55,7 @@ public class ResolverElement implements Comparable<ResolverElement> {
     return MoreObjects
       .toStringHelper(this)
       .add("matchSize", matchSize)
-      .add("config", config)
+      .add("config", configElement)
       .add("configValue", configValue)
       .add("match", match)
       .toString();

--- a/src/test/java/cloud/prefab/client/config/ConfigResolverTest.java
+++ b/src/test/java/cloud/prefab/client/config/ConfigResolverTest.java
@@ -239,8 +239,8 @@ public class ConfigResolverTest {
     resolver.update();
     String expected =
       "\n" +
-      "key1                          value_no_env_default                    ResolverElement{source=LOCAL_ONLY, sourceLocation=unit test, match=default}               \n" +
-      "key2                          valueB2                                 ResolverElement{source=LOCAL_ONLY, sourceLocation=unit test, match=default}               \n";
+      "key1                          value_no_env_default                    LOCAL_ONLY:unit test:default                                                              \n" +
+      "key2                          valueB2                                 LOCAL_ONLY:unit test:default                                                              \n";
     assertThat(resolver.contentsString()).isEqualTo(expected);
   }
 

--- a/src/test/java/cloud/prefab/client/config/ConfigResolverTest.java
+++ b/src/test/java/cloud/prefab/client/config/ConfigResolverTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import cloud.prefab.client.ConfigClient;
 import cloud.prefab.client.Options;
 import cloud.prefab.client.PrefabCloudClient;
 import cloud.prefab.domain.Prefab;
@@ -70,22 +71,24 @@ public class ConfigResolverTest {
       );
   }
 
-  private Map<String, Prefab.Config> testDataAddingKey3andTombstoningKey1() {
-    Map<String, Prefab.Config> rtn = new HashMap<>();
-    rtn.put("key1", Prefab.Config.newBuilder().setKey("key1").build());
-    rtn.put("key2", key2());
+  private Map<String, ConfigElement> testDataAddingKey3andTombstoningKey1() {
+    Map<String, ConfigElement> rtn = new HashMap<>();
+    rtn.put("key1", ce(Prefab.Config.newBuilder().setKey("key1").build()));
+    rtn.put("key2", ce(key2()));
     rtn.put(
       "key3",
-      Prefab.Config
-        .newBuilder()
-        .setKey("key1")
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setValue(Prefab.ConfigValue.newBuilder().setString("key3").build())
-            .build()
-        )
-        .build()
+      ce(
+        Prefab.Config
+          .newBuilder()
+          .setKey("key1")
+          .addRows(
+            Prefab.ConfigRow
+              .newBuilder()
+              .setValue(Prefab.ConfigValue.newBuilder().setString("key3").build())
+              .build()
+          )
+          .build()
+      )
     );
     return rtn;
   }
@@ -108,80 +111,82 @@ public class ConfigResolverTest {
   public void testSpecialFeatureFlagBehavior() {
     final ConfigLoader mockLoader = mock(ConfigLoader.class);
 
-    Map<String, Prefab.Config> testFFData = new HashMap<>();
+    Map<String, ConfigElement> testFFData = new HashMap<>();
 
     String featureName = "ff";
     testFFData.put(
       featureName,
-      Prefab.Config
-        .newBuilder()
-        .addVariants(Prefab.FeatureFlagVariant.newBuilder().setString("v1").build())
-        .addVariants(Prefab.FeatureFlagVariant.newBuilder().setString("v2").build())
-        .addVariants(
-          Prefab.FeatureFlagVariant.newBuilder().setString("variantInEnv").build()
-        )
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setValue(
-              Prefab.ConfigValue
-                .newBuilder()
-                .setFeatureFlag(
-                  Prefab.FeatureFlag
-                    .newBuilder()
-                    .setActive(true)
-                    .setInactiveVariantIdx(0)
-                    .addRules(
-                      Prefab.Rule
-                        .newBuilder()
-                        .setCriteria(
-                          Prefab.Criteria
-                            .newBuilder()
-                            .setOperator(Prefab.Criteria.CriteriaOperator.ALWAYS_TRUE)
-                            .build()
-                        )
-                        .addVariantWeights(
-                          Prefab.VariantWeight.newBuilder().setVariantIdx(1).build()
-                        )
-                    )
-                    .build()
-                )
-                .build()
-            )
-            .build()
-        )
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setProjectEnvId(33)
-            .setValue(
-              Prefab.ConfigValue
-                .newBuilder()
-                .setFeatureFlag(
-                  Prefab.FeatureFlag
-                    .newBuilder()
-                    .setActive(true)
-                    .setInactiveVariantIdx(0)
-                    .addRules(
-                      Prefab.Rule
-                        .newBuilder()
-                        .setCriteria(
-                          Prefab.Criteria
-                            .newBuilder()
-                            .setOperator(Prefab.Criteria.CriteriaOperator.ALWAYS_TRUE)
-                            .build()
-                        )
-                        .addVariantWeights(
-                          Prefab.VariantWeight.newBuilder().setVariantIdx(2).build()
-                        )
-                    )
-                    .build()
-                )
-                .build()
-            )
-            .build()
-        )
-        .build()
+      ce(
+        Prefab.Config
+          .newBuilder()
+          .addVariants(Prefab.FeatureFlagVariant.newBuilder().setString("v1").build())
+          .addVariants(Prefab.FeatureFlagVariant.newBuilder().setString("v2").build())
+          .addVariants(
+            Prefab.FeatureFlagVariant.newBuilder().setString("variantInEnv").build()
+          )
+          .addRows(
+            Prefab.ConfigRow
+              .newBuilder()
+              .setValue(
+                Prefab.ConfigValue
+                  .newBuilder()
+                  .setFeatureFlag(
+                    Prefab.FeatureFlag
+                      .newBuilder()
+                      .setActive(true)
+                      .setInactiveVariantIdx(0)
+                      .addRules(
+                        Prefab.Rule
+                          .newBuilder()
+                          .setCriteria(
+                            Prefab.Criteria
+                              .newBuilder()
+                              .setOperator(Prefab.Criteria.CriteriaOperator.ALWAYS_TRUE)
+                              .build()
+                          )
+                          .addVariantWeights(
+                            Prefab.VariantWeight.newBuilder().setVariantIdx(1).build()
+                          )
+                      )
+                      .build()
+                  )
+                  .build()
+              )
+              .build()
+          )
+          .addRows(
+            Prefab.ConfigRow
+              .newBuilder()
+              .setProjectEnvId(33)
+              .setValue(
+                Prefab.ConfigValue
+                  .newBuilder()
+                  .setFeatureFlag(
+                    Prefab.FeatureFlag
+                      .newBuilder()
+                      .setActive(true)
+                      .setInactiveVariantIdx(0)
+                      .addRules(
+                        Prefab.Rule
+                          .newBuilder()
+                          .setCriteria(
+                            Prefab.Criteria
+                              .newBuilder()
+                              .setOperator(Prefab.Criteria.CriteriaOperator.ALWAYS_TRUE)
+                              .build()
+                          )
+                          .addVariantWeights(
+                            Prefab.VariantWeight.newBuilder().setVariantIdx(2).build()
+                          )
+                      )
+                      .build()
+                  )
+                  .build()
+              )
+              .build()
+          )
+          .build()
+      )
     );
 
     when(mockLoader.calcConfig()).thenReturn(testFFData);
@@ -229,6 +234,16 @@ public class ConfigResolverTest {
     assertThat(resolver.getConfigValue("key_that_doesnt_exist").isPresent()).isFalse();
   }
 
+  @Test
+  public void testContentsString() {
+    resolver.update();
+    String expected =
+      "\n" +
+      "key1                          value_no_env_default                    ResolverElement{source=LOCAL_ONLY, sourceLocation=unit test, match=default}               \n" +
+      "key2                          valueB2                                 ResolverElement{source=LOCAL_ONLY, sourceLocation=unit test, match=default}               \n";
+    assertThat(resolver.contentsString()).isEqualTo(expected);
+  }
+
   private void assertConfigValueStringIs(
     Optional<Prefab.ConfigValue> key,
     String expectedValue
@@ -236,68 +251,73 @@ public class ConfigResolverTest {
     assertThat(key.get().getString()).isEqualTo(expectedValue);
   }
 
-  private Map<String, Prefab.Config> testData() {
-    Map<String, Prefab.Config> rtn = new HashMap<>();
-    rtn.put(
-      "key1",
-      Prefab.Config
-        .newBuilder()
-        .setKey("key1")
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setValue(
-              Prefab.ConfigValue.newBuilder().setString("value_no_env_default").build()
-            )
-            .build()
-        )
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setProjectEnvId(TEST_PROJ_ENV)
-            .setValue(Prefab.ConfigValue.newBuilder().setString("value_none").build())
-            .build()
-        )
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setProjectEnvId(TEST_PROJ_ENV)
-            .setNamespace("projectA")
-            .setValue(Prefab.ConfigValue.newBuilder().setString("valueA").build())
-            .build()
-        )
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setProjectEnvId(TEST_PROJ_ENV)
-            .setNamespace("projectB")
-            .setValue(Prefab.ConfigValue.newBuilder().setString("valueB").build())
-            .build()
-        )
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setProjectEnvId(TEST_PROJ_ENV)
-            .setNamespace("projectB.subprojectX")
-            .setValue(
-              Prefab.ConfigValue.newBuilder().setString("projectB.subprojectX").build()
-            )
-            .build()
-        )
-        .addRows(
-          Prefab.ConfigRow
-            .newBuilder()
-            .setProjectEnvId(TEST_PROJ_ENV)
-            .setNamespace("projectB.subprojectY")
-            .setValue(
-              Prefab.ConfigValue.newBuilder().setString("projectB.subprojectY").build()
-            )
-            .build()
-        )
-        .build()
-    );
-    rtn.put("key2", key2());
+  private Map<String, ConfigElement> testData() {
+    Map<String, ConfigElement> rtn = new HashMap<>();
+    rtn.put("key1", ce(key1()));
+    rtn.put("key2", ce(key2()));
     return rtn;
+  }
+
+  private ConfigElement ce(Prefab.Config config) {
+    return new ConfigElement(config, ConfigClient.Source.LOCAL_ONLY, "unit test");
+  }
+
+  private Prefab.Config key1() {
+    return Prefab.Config
+      .newBuilder()
+      .setKey("key1")
+      .addRows(
+        Prefab.ConfigRow
+          .newBuilder()
+          .setValue(
+            Prefab.ConfigValue.newBuilder().setString("value_no_env_default").build()
+          )
+          .build()
+      )
+      .addRows(
+        Prefab.ConfigRow
+          .newBuilder()
+          .setProjectEnvId(TEST_PROJ_ENV)
+          .setValue(Prefab.ConfigValue.newBuilder().setString("value_none").build())
+          .build()
+      )
+      .addRows(
+        Prefab.ConfigRow
+          .newBuilder()
+          .setProjectEnvId(TEST_PROJ_ENV)
+          .setNamespace("projectA")
+          .setValue(Prefab.ConfigValue.newBuilder().setString("valueA").build())
+          .build()
+      )
+      .addRows(
+        Prefab.ConfigRow
+          .newBuilder()
+          .setProjectEnvId(TEST_PROJ_ENV)
+          .setNamespace("projectB")
+          .setValue(Prefab.ConfigValue.newBuilder().setString("valueB").build())
+          .build()
+      )
+      .addRows(
+        Prefab.ConfigRow
+          .newBuilder()
+          .setProjectEnvId(TEST_PROJ_ENV)
+          .setNamespace("projectB.subprojectX")
+          .setValue(
+            Prefab.ConfigValue.newBuilder().setString("projectB.subprojectX").build()
+          )
+          .build()
+      )
+      .addRows(
+        Prefab.ConfigRow
+          .newBuilder()
+          .setProjectEnvId(TEST_PROJ_ENV)
+          .setNamespace("projectB.subprojectY")
+          .setValue(
+            Prefab.ConfigValue.newBuilder().setString("projectB.subprojectY").build()
+          )
+          .build()
+      )
+      .build();
   }
 
   private static Prefab.Config key2() {

--- a/src/test/java/cloud/prefab/client/value/AbstractLiveValueTest.java
+++ b/src/test/java/cloud/prefab/client/value/AbstractLiveValueTest.java
@@ -37,7 +37,7 @@ class AbstractLiveValueTest {
         Optional.of(Prefab.ConfigValue.newBuilder().setString("mismatch").build())
       );
     when(mockConfigClient.get("boolean"))
-      .thenReturn(Optional.of(Prefab.ConfigValue.newBuilder().setBool(true).build()));
+      .thenReturn(Optional.of(Prefab.ConfigValue.newBuilder().setBool(false).build()));
     when(mockConfigClient.get("boolean mismatch"))
       .thenReturn(
         Optional.of(Prefab.ConfigValue.newBuilder().setString("mismatch").build())
@@ -61,7 +61,7 @@ class AbstractLiveValueTest {
       TypeMismatchException.class,
       () -> new LiveDouble(mockConfigClient, "double mismatch").get()
     );
-    assertEquals(true, new LiveBoolean(mockConfigClient, "boolean").get());
+    assertEquals(false, new LiveBoolean(mockConfigClient, "boolean").get());
     assertThrows(
       TypeMismatchException.class,
       () -> new LiveBoolean(mockConfigClient, "boolean mismatch").get()


### PR DESCRIPTION
Store the provenance of configs so that we can display them back to the user as useful debug info. 

```
log-level.io.micronaut.web.ro DEBUG                                   CLASSPATH:.prefab.default.config.yaml:default                                             
log-level.prefab              INFO                                    CLASSPATH:.prefab.default.config.yaml:default                                             
my-cool-feature               FeatureFlag                             REMOTE_CDN::Env:100                                                                       
A                             3                                       REMOTE_CDN::default                                                                       
segment.prefab-devs           Segment                                 REMOTE_CDN::Env:100                                                                       
log-level.app.models.user     WARN                                    REMOTE_CDN::default                                                                       
log-level.prefab.logging      WARN                                    REMOTE_CDN::default           
```