### PR TITLE
Proof of concept for consuming language-agnostic integration test data

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,3 +27,6 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+      env:
+        PREFAB_INTEGRATION_TEST_API_KEY: ${{ secrets.PREFAB_INTEGRATION_TEST_API_KEY }}
+        PREFAB_API_KEY: 1-fake-apikey

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ buildNumber.properties
 
 Tester.java
 README_INTERNAL.md
+.envrc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "prefab-cloud"]
 	path = prefab-cloud
 	url = git@github.com:prefab-cloud/prefab-cloud.git
+[submodule "src/test/resources/prefab-cloud-integration-test-data"]
+	path = src/test/resources/prefab-cloud-integration-test-data
+	url = git@github.com:prefab-cloud/prefab-cloud-integration-test-data

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
 
     <dep.grpc.version>1.48.0</dep.grpc.version>
+    <dep.jackson.version>2.14.1</dep.jackson.version>
     <dep.protobuf.version>3.21.3</dep.protobuf.version>
     <dep.protoc.version>3.21.3</dep.protoc.version>
   </properties>
@@ -30,6 +31,16 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>1.4.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${dep.jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jdk8</artifactId>
+        <version>${dep.jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>
@@ -199,6 +210,16 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/src/main/java/cloud/prefab/client/PrefabCloudClient.java
+++ b/src/main/java/cloud/prefab/client/PrefabCloudClient.java
@@ -2,24 +2,24 @@ package cloud.prefab.client;
 
 import cloud.prefab.client.util.Cache;
 import cloud.prefab.client.util.NoopCache;
+import com.google.common.base.Preconditions;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PrefabCloudClient {
+public class PrefabCloudClient implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrefabCloudClient.class);
 
   private final Options options;
-  private ManagedChannel channel;
+  private volatile ManagedChannel channel;
   private RateLimitClient rateLimitClient;
   private ConfigClient configClient;
   private FeatureFlagClient featureFlagClient;
   private Cache noopCache;
+  private final AtomicBoolean closed;
 
   public PrefabCloudClient(Options options) {
     this.options = options;
@@ -34,6 +34,8 @@ public class PrefabCloudClient {
       long apiKeyId = Long.parseLong(options.getApikey().split("\\-")[0]);
       LOG.info("Initializing Prefab for apiKeyId {}", apiKeyId);
     }
+
+    this.closed = new AtomicBoolean(false);
   }
 
   public RateLimitClient rateLimitClient() {
@@ -58,9 +60,17 @@ public class PrefabCloudClient {
   }
 
   public ManagedChannel getChannel() {
+    Preconditions.checkState(!closed.get(), "Client is closed");
+
     if (channel == null) {
-      channel = createChannel();
+      synchronized (this) {
+        if (channel == null) {
+          Preconditions.checkState(!closed.get(), "Client is closed");
+          channel = createChannel();
+        }
+      }
     }
+
     return channel;
   }
 
@@ -91,5 +101,22 @@ public class PrefabCloudClient {
     return managedChannelBuilder
       .intercept(new ClientAuthenticationInterceptor(options.getApikey()))
       .build();
+  }
+
+  @Override
+  public void close() {
+    if (closed.get()) {
+      return;
+    }
+
+    synchronized (this) {
+      if (!closed.get()) {
+        if (channel != null) {
+          channel.shutdown();
+        }
+
+        closed.set(true);
+      }
+    }
   }
 }

--- a/src/test/java/cloud/prefab/client/IntegrationTest.java
+++ b/src/test/java/cloud/prefab/client/IntegrationTest.java
@@ -1,0 +1,60 @@
+package cloud.prefab.client;
+
+import cloud.prefab.client.integration.IntegrationTestFile;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+public class IntegrationTest {
+
+  private static final Path INTEGRATION_TEST_DATA_DIRECTORY = Paths.get(
+    "src/test/resources/prefab-cloud-integration-test-data"
+  );
+
+  private static final ObjectReader YAML_READER = new YAMLMapper()
+    .registerModule(new Jdk8Module())
+    .reader();
+
+  @TestFactory
+  public Collection<DynamicTest> runIntegrationTests() throws IOException {
+    return findIntegrationTestFiles()
+      .stream()
+      .map(IntegrationTest::parseTestFile)
+      .flatMap(IntegrationTestFile::buildDynamicTests)
+      .collect(ImmutableList.toImmutableList());
+  }
+
+  private static List<Path> findIntegrationTestFiles() throws IOException {
+    try (
+      Stream<Path> stream = Files.list(
+        INTEGRATION_TEST_DATA_DIRECTORY
+          .resolve("tests")
+          .resolve(getIntegrationTestsVersion())
+      )
+    ) {
+      return stream.collect(ImmutableList.toImmutableList());
+    }
+  }
+
+  private static IntegrationTestFile parseTestFile(Path testFile) {
+    try {
+      return YAML_READER.readValue(testFile.toFile(), IntegrationTestFile.class);
+    } catch (IOException e) {
+      throw new RuntimeException("Error parsing test file: " + testFile, e);
+    }
+  }
+
+  private static String getIntegrationTestsVersion() throws IOException {
+    return Files.readString(INTEGRATION_TEST_DATA_DIRECTORY.resolve("version")).trim();
+  }
+}

--- a/src/test/java/cloud/prefab/client/config/ConfigLoaderTest.java
+++ b/src/test/java/cloud/prefab/client/config/ConfigLoaderTest.java
@@ -104,7 +104,7 @@ public class ConfigLoaderTest {
   public void test_nested() {
     assertValueOfConfigIs("nested value", "nested.values.string");
     assertValueOfConfigIs("top level", "nested.values");
-    assertValueOfConfigIsLogLevel(Prefab.LogLevel.DEBUG, "log-level.tests.nested");
+    assertValueOfConfigIsLogLevel(Prefab.LogLevel.WARN, "log-level.tests.nested");
     assertValueOfConfigIsLogLevel(Prefab.LogLevel.ERROR, "log-level.tests.nested.deeply");
   }
 

--- a/src/test/java/cloud/prefab/client/integration/IntegrationTestClientOverrides.java
+++ b/src/test/java/cloud/prefab/client/integration/IntegrationTestClientOverrides.java
@@ -1,0 +1,32 @@
+package cloud.prefab.client.integration;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+
+public class IntegrationTestClientOverrides {
+
+  private final Optional<String> namespace;
+  private final Optional<Integer> onNoDefault;
+
+  @JsonCreator
+  public IntegrationTestClientOverrides(
+    @JsonProperty("namespace") Optional<String> namespace,
+    @JsonProperty("on_no_default") Optional<Integer> onNoDefault
+  ) {
+    this.namespace = namespace;
+    this.onNoDefault = onNoDefault;
+  }
+
+  public static IntegrationTestClientOverrides empty() {
+    return new IntegrationTestClientOverrides(Optional.empty(), Optional.empty());
+  }
+
+  public Optional<String> getNamespace() {
+    return namespace;
+  }
+
+  public Optional<Integer> getOnNoDefault() {
+    return onNoDefault;
+  }
+}

--- a/src/test/java/cloud/prefab/client/integration/IntegrationTestDescriptor.java
+++ b/src/test/java/cloud/prefab/client/integration/IntegrationTestDescriptor.java
@@ -1,0 +1,81 @@
+package cloud.prefab.client.integration;
+
+import cloud.prefab.client.Options;
+import cloud.prefab.client.PrefabCloudClient;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.errorprone.annotations.MustBeClosed;
+import org.junit.jupiter.api.function.Executable;
+
+public class IntegrationTestDescriptor {
+
+  private final String name;
+  private final String client;
+  private final IntegrationTestFunction function;
+  private final IntegrationTestClientOverrides clientOverrides;
+  private final IntegrationTestInput input;
+  private final IntegrationTestExpectation expected;
+
+  @JsonCreator
+  public IntegrationTestDescriptor(
+    @JsonProperty("name") String name,
+    @JsonProperty("client") String client,
+    @JsonProperty("function") IntegrationTestFunction function,
+    @JsonProperty("client_overrides") IntegrationTestClientOverrides clientOverrides,
+    @JsonProperty("input") IntegrationTestInput input,
+    @JsonProperty("expected") IntegrationTestExpectation expected
+  ) {
+    this.name = name;
+    this.client = client;
+    this.function = function;
+    this.clientOverrides =
+      MoreObjects.firstNonNull(clientOverrides, IntegrationTestClientOverrides.empty());
+    this.input = input;
+    this.expected = expected;
+  }
+
+  public Executable asExecutable() {
+    return () -> {
+      try (PrefabCloudClient client = buildClient(clientOverrides)) {
+        getExpected().verifyScenario(client, getFunction(), getInput());
+      }
+    };
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getClient() {
+    return client;
+  }
+
+  public IntegrationTestFunction getFunction() {
+    return function;
+  }
+
+  public IntegrationTestClientOverrides getClientOverrides() {
+    return clientOverrides;
+  }
+
+  public IntegrationTestInput getInput() {
+    return input;
+  }
+
+  public IntegrationTestExpectation getExpected() {
+    return expected;
+  }
+
+  @MustBeClosed
+  private PrefabCloudClient buildClient(IntegrationTestClientOverrides clientOverrides) {
+    Options options = new Options()
+      .setApikey(System.getenv("PREFAB_INTEGRATION_TEST_API_KEY"))
+      .setPrefabGrpcUrl("grpc.staging-prefab.cloud:443")
+      .setPrefabApiUrl("https://api.staging-prefab.cloud");
+
+    clientOverrides.getNamespace().ifPresent(options::setNamespace);
+
+    return new PrefabCloudClient(options);
+  }
+}

--- a/src/test/java/cloud/prefab/client/integration/IntegrationTestExpectation.java
+++ b/src/test/java/cloud/prefab/client/integration/IntegrationTestExpectation.java
@@ -1,0 +1,88 @@
+package cloud.prefab.client.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import cloud.prefab.client.PrefabCloudClient;
+import cloud.prefab.client.integration.IntegrationTestExpectation.VerifyException;
+import cloud.prefab.client.integration.IntegrationTestExpectation.VerifyReturnValue;
+import cloud.prefab.client.value.UndefinedKeyException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+@JsonTypeInfo(use = Id.NAME, property = "status", defaultImpl = VerifyReturnValue.class)
+@JsonSubTypes(
+  {
+    @Type(value = VerifyReturnValue.class, name = "return"),
+    @Type(value = VerifyException.class, name = "raise"),
+  }
+)
+public interface IntegrationTestExpectation {
+  void verifyScenario(
+    PrefabCloudClient client,
+    IntegrationTestFunction function,
+    IntegrationTestInput input
+  );
+
+  class VerifyReturnValue implements IntegrationTestExpectation {
+
+    @Nullable
+    private final String expectedValue;
+
+    @JsonCreator
+    private VerifyReturnValue(@JsonProperty("value") @Nullable String expectedValue) {
+      this.expectedValue = expectedValue;
+    }
+
+    @Override
+    public void verifyScenario(
+      PrefabCloudClient client,
+      IntegrationTestFunction function,
+      IntegrationTestInput input
+    ) {
+      assertThat(function.apply(client, input)).isEqualTo(expectedValue);
+    }
+  }
+
+  class VerifyException implements IntegrationTestExpectation {
+
+    private static final Map<String, Class<?>> ERROR_TYPES = ImmutableMap.of(
+      "missing_default",
+      UndefinedKeyException.class
+    );
+
+    private final String error;
+    private final String message;
+
+    @JsonCreator
+    public VerifyException(
+      @JsonProperty("error") String error,
+      @JsonProperty("message") String message
+    ) {
+      this.error = error;
+      this.message = message;
+    }
+
+    @Override
+    public void verifyScenario(
+      PrefabCloudClient client,
+      IntegrationTestFunction function,
+      IntegrationTestInput input
+    ) {
+      Class<?> errorClass = ERROR_TYPES.get(error);
+      assertThat(errorClass).describedAs("Unknown error type: %s", error).isNotNull();
+
+      Throwable t = catchThrowable(() -> function.apply(client, input));
+      // TODO: the error messages are not currently standard across our clients.
+      //assertThat(t).isInstanceOf(errorClass).hasMessageContaining(message);
+      assertThat(t).isInstanceOf(errorClass);
+    }
+  }
+}

--- a/src/test/java/cloud/prefab/client/integration/IntegrationTestFile.java
+++ b/src/test/java/cloud/prefab/client/integration/IntegrationTestFile.java
@@ -1,0 +1,50 @@
+package cloud.prefab.client.integration;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Joiner;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+
+public class IntegrationTestFile {
+
+  private final String version;
+  private final String function;
+  private final List<IntegrationTestDescriptor> tests;
+
+  @JsonCreator
+  public IntegrationTestFile(
+    @JsonProperty("version") String version,
+    @JsonProperty("function") String function,
+    @JsonProperty("tests") List<IntegrationTestDescriptor> tests
+  ) {
+    this.version = version;
+    this.function = function;
+    this.tests = tests;
+  }
+
+  public Stream<DynamicTest> buildDynamicTests() {
+    return tests
+      .stream()
+      .map(testDescriptor -> {
+        String displayName = Joiner
+          .on(" : ")
+          .join(version, function, testDescriptor.getName());
+
+        return DynamicTest.dynamicTest(displayName, testDescriptor.asExecutable());
+      });
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getFunction() {
+    return function;
+  }
+
+  public List<IntegrationTestDescriptor> getTests() {
+    return tests;
+  }
+}

--- a/src/test/java/cloud/prefab/client/integration/IntegrationTestFunction.java
+++ b/src/test/java/cloud/prefab/client/integration/IntegrationTestFunction.java
@@ -1,0 +1,61 @@
+package cloud.prefab.client.integration;
+
+import cloud.prefab.client.PrefabCloudClient;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+
+public enum IntegrationTestFunction {
+  GET_OR_RAISE("get_or_raise") {
+    @Override
+    public String apply(PrefabCloudClient client, IntegrationTestInput input) {
+      return input.getWithoutFallback(client);
+    }
+  },
+  GET("get") {
+    @Override
+    public String apply(PrefabCloudClient client, IntegrationTestInput input) {
+      if (input.getFlag().isPresent()) {
+        return String.valueOf(input.getFeatureFor(client));
+      } else {
+        return input.getWithFallback(client);
+      }
+    }
+  },
+  ENABLED("enabled") {
+    @Override
+    public String apply(PrefabCloudClient client, IntegrationTestInput input) {
+      return String.valueOf(input.featureIsOnFor(client));
+    }
+  };
+
+  private static final Map<String, IntegrationTestFunction> JSON_INDEX = Arrays
+    .stream(IntegrationTestFunction.values())
+    .collect(
+      ImmutableMap.toImmutableMap(
+        IntegrationTestFunction::getJsonValue,
+        Function.identity()
+      )
+    );
+
+  private final String jsonValue;
+
+  IntegrationTestFunction(String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  @JsonCreator
+  public static IntegrationTestFunction fromJsonValue(String jsonValue) {
+    return JSON_INDEX.get(jsonValue);
+  }
+
+  @JsonValue
+  public String getJsonValue() {
+    return jsonValue;
+  }
+
+  public abstract String apply(PrefabCloudClient client, IntegrationTestInput input);
+}

--- a/src/test/java/cloud/prefab/client/integration/IntegrationTestInput.java
+++ b/src/test/java/cloud/prefab/client/integration/IntegrationTestInput.java
@@ -1,0 +1,94 @@
+package cloud.prefab.client.integration;
+
+import cloud.prefab.client.PrefabCloudClient;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class IntegrationTestInput {
+
+  private final String key;
+  private final Optional<String> flag;
+  private final String lookupKey;
+  private final Map<String, String> properties;
+  private final Optional<String> defaultValue;
+
+  @JsonCreator
+  public IntegrationTestInput(
+    @JsonProperty("key") String key,
+    @JsonProperty("flag") Optional<String> flag,
+    @JsonProperty("lookup_key") String lookupKey,
+    @JsonProperty("properties") Map<String, String> properties,
+    @JsonProperty("default") Optional<String> defaultValue
+  ) {
+    this.key = key;
+    this.flag = flag;
+    this.lookupKey = lookupKey;
+    this.properties = properties;
+    this.defaultValue = defaultValue;
+  }
+
+  public String getWithFallback(PrefabCloudClient client) {
+    return client.configClient().liveString(getKey()).or(defaultValue.orElse(null));
+  }
+
+  public String getWithoutFallback(PrefabCloudClient client) {
+    if (defaultValue.isPresent()) {
+      return getWithFallback(client);
+    } else {
+      return client.configClient().liveString(getKey()).get();
+    }
+  }
+
+  public boolean featureIsOnFor(PrefabCloudClient client) {
+    return client
+      .featureFlagClient()
+      .featureIsOnFor(getFlag().get(), getResolvedLookupKey(), getResolvedProperties());
+  }
+
+  public long getFeatureFor(PrefabCloudClient client) {
+    return client
+      .featureFlagClient()
+      .get(getFlag().get(), getResolvedLookupKey(), getResolvedProperties())
+      .get()
+      .getInt();
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public Optional<String> getFlag() {
+    return flag;
+  }
+
+  public String getLookupKey() {
+    return lookupKey;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public Optional<String> getDefault() {
+    return defaultValue;
+  }
+
+  private Optional<String> getResolvedLookupKey() {
+    if (lookupKey == null) {
+      return Optional.empty();
+    } else {
+      return Optional.of(lookupKey);
+    }
+  }
+
+  private Map<String, String> getResolvedProperties() {
+    if (getProperties() == null) {
+      return ImmutableMap.of();
+    } else {
+      return getProperties();
+    }
+  }
+}

--- a/src/test/resources/.prefab.unit_tests.config.yaml
+++ b/src/test/resources/.prefab.unit_tests.config.yaml
@@ -17,10 +17,12 @@ nested:
     string: nested value
 
 log-level:
+  _: warn
+  cloud.prefab.client: warn
   tests:
     _: debug
     capitalized: INFO
     uncapitalized: info
     nested:
-      _: debug
+      _: warn
       deeply: error


### PR DESCRIPTION
This work creates a `@TestFactory` that generates `DynamicTests` from a set of YAML files in a submodule. The goal of this submodule is to provide a set of common integration tests that we can run against all our clients. While originally designed and tested on dynamic languages, we have found a workable solution in Java. 