### PR TITLE
Remove getAllValues method from client interface

### DIFF
--- a/client/src/main/java/cloud/prefab/client/ConfigClient.java
+++ b/client/src/main/java/cloud/prefab/client/ConfigClient.java
@@ -25,8 +25,6 @@ public interface ConfigClient {
     Map<String, Prefab.ConfigValue> properties
   );
 
-  public Map<String, Prefab.ConfigValue> getAllValues();
-
   void upsert(String key, Prefab.ConfigValue configValue);
 
   void upsert(Prefab.Config config);

--- a/client/src/main/java/cloud/prefab/client/config/ConfigResolver.java
+++ b/client/src/main/java/cloud/prefab/client/config/ConfigResolver.java
@@ -61,7 +61,13 @@ public class ConfigResolver {
     return getMatch(key, properties).map(Match::getConfigValue);
   }
 
-  public Map<String, Prefab.ConfigValue> getAllValues() {
+  /**
+   * Get all currently known parameter-less config values.
+   * ConfigValues that are not visible unless passed an appropriate map of parameters are not here
+   * Note: these values ARE NOT LIVE and will not change values
+   * @return
+   */
+  public Map<String, Prefab.ConfigValue> getAllCurrentValues() {
     ImmutableMap.Builder<String, Prefab.ConfigValue> allValues = ImmutableMap.builder();
     for (String key : getKeys()) {
       getConfigValue(key).ifPresent(configValue -> allValues.put(key, configValue));

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
@@ -147,10 +147,6 @@ public class ConfigClientImpl implements ConfigClient {
     }
   }
 
-  public Map<String, Prefab.ConfigValue> getAllValues() {
-    return getResolver().getAllValues();
-  }
-
   @Override
   public void upsert(String key, Prefab.ConfigValue configValue) {
     Prefab.Config upsertRequest = Prefab.Config


### PR DESCRIPTION
Java doc and renamed the method on ConfigResolver to indicate that the values are not live

This reverses much of https://github.com/prefab-cloud/prefab-cloud-java/pull/38 until we have a replacement implementation that returns either types or the live values themselves