### PR TITLE
Logger volume reporting

### DIFF
--- a/client/src/main/java/cloud/prefab/client/ConfigClient.java
+++ b/client/src/main/java/cloud/prefab/client/ConfigClient.java
@@ -33,7 +33,9 @@ public interface ConfigClient {
 
   boolean removeConfigChangeListener(ConfigChangeListener configChangeListener);
 
-  public enum Source {
+  void reportLoggerUsage(String loggerName, Prefab.LogLevel logLevel, long count);
+
+  enum Source {
     REMOTE_API_GRPC,
     STREAMING,
     REMOTE_CDN,

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
@@ -90,14 +90,15 @@ public class ConfigClientImpl implements ConfigClient {
       new LoggingConfigListener(() -> initializedLatch.getCount() == 0)
     );
     configChangeListeners.addAll(Arrays.asList(listeners));
-    loggerStatsAggregator = new LoggerStatsAggregator(Clock.systemUTC());
-    loggerStatsAggregator.start();
 
     if (options.isLocalOnly()) {
       finishInit(Source.LOCAL_ONLY);
+      loggerStatsAggregator = null;
     } else {
       startStreamingExecutor();
       startCheckpointExecutor();
+      loggerStatsAggregator = new LoggerStatsAggregator(Clock.systemUTC());
+      loggerStatsAggregator.start();
       startLogStatsUploadExecutor();
     }
   }
@@ -193,7 +194,7 @@ public class ConfigClientImpl implements ConfigClient {
 
   @Override
   public void reportLoggerUsage(String loggerName, Prefab.LogLevel logLevel, long count) {
-    if (logLevel != null) {
+    if (logLevel != null && loggerStatsAggregator != null) {
       loggerStatsAggregator.reportLoggerUsage(loggerName, logLevel, count);
     }
   }

--- a/client/src/main/java/cloud/prefab/client/internal/LoggerStatsAggregator.java
+++ b/client/src/main/java/cloud/prefab/client/internal/LoggerStatsAggregator.java
@@ -116,6 +116,9 @@ class LoggerStatsAggregator {
       case ERROR:
         loggerBuilder.setErrors(count);
         break;
+      case FATAL:
+        loggerBuilder.setFatals(count);
+        break;
     }
 
     try {
@@ -133,6 +136,7 @@ class LoggerStatsAggregator {
     long infos = loggerToMutate.getInfos();
     long warns = loggerToMutate.getWarns();
     long errors = loggerToMutate.getErrors();
+    long fatals = loggerToMutate.getFatals();
 
     while (iter.hasNext()) {
       Prefab.Logger logger = iter.next();
@@ -141,6 +145,7 @@ class LoggerStatsAggregator {
       infos += logger.getInfos();
       warns += logger.getWarns();
       errors += logger.getErrors();
+      fatals += logger.getFatals();
     }
 
     return loggerToMutate
@@ -150,6 +155,7 @@ class LoggerStatsAggregator {
       .setInfos(infos)
       .setWarns(warns)
       .setErrors(errors)
+      .setFatals(fatals)
       .build();
   }
 
@@ -161,6 +167,7 @@ class LoggerStatsAggregator {
       .setInfos(a.getInfos() + b.getInfos())
       .setWarns(a.getWarns() + b.getWarns())
       .setErrors(a.getErrors() + b.getErrors())
+      .setFatals(a.getFatals() + b.getFatals())
       .build();
   }
 

--- a/client/src/main/java/cloud/prefab/client/internal/LoggerStatsAggregator.java
+++ b/client/src/main/java/cloud/prefab/client/internal/LoggerStatsAggregator.java
@@ -1,0 +1,198 @@
+package cloud.prefab.client.internal;
+
+import cloud.prefab.domain.Prefab;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class LoggerStatsAggregator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LoggerStatsAggregator.class);
+
+  private final Clock clock;
+
+  private final AtomicReference<LogCounts> currentLogCollection = new AtomicReference<>();
+
+  LoggerStatsAggregator(Clock clock) {
+    this.clock = clock;
+    currentLogCollection.set(new LogCounts(clock.millis()));
+  }
+
+  private final LinkedBlockingQueue<Prefab.Logger> loggerCountQueue = new LinkedBlockingQueue<>(
+    100_000
+  );
+
+  void start() {
+    ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(
+      1,
+      r -> new Thread(r, "prefab-log-stats-aggregator")
+    );
+    ScheduledExecutorService executorService = MoreExecutors.getExitingScheduledExecutorService(
+      executor,
+      100,
+      TimeUnit.MILLISECONDS
+    );
+    executorService.scheduleAtFixedRate(
+      () -> {
+        try {
+          aggregate();
+        } catch (Exception e) {
+          LOG.debug("error in aggregator", e);
+        }
+      },
+      100,
+      100,
+      TimeUnit.MILLISECONDS
+    );
+  }
+
+  @VisibleForTesting
+  void aggregate() {
+    int drainSize = 10_000;
+    List<Prefab.Logger> drain = new ArrayList<>(drainSize);
+    int drainCount = loggerCountQueue.drainTo(drain, drainSize);
+    if (drainCount > 0) {
+      Map<String, Prefab.Logger> aggregates = drain
+        .stream()
+        .collect(
+          Collectors.groupingBy(
+            Prefab.Logger::getLoggerName,
+            Collectors.collectingAndThen(
+              Collectors.toList(),
+              LoggerStatsAggregator::mergeLoggerCollection
+            )
+          )
+        );
+
+      currentLogCollection.get().updateLoggerMap(aggregates.values());
+    }
+  }
+
+  LogCounts getAndResetStats() {
+    return currentLogCollection.getAndSet(new LogCounts(clock.millis()));
+  }
+
+  void reportLoggerUsage(String loggerName, Prefab.LogLevel logLevel, long count) {
+    Prefab.Logger.Builder loggerBuilder = Prefab.Logger
+      .newBuilder()
+      .setLoggerName(loggerName);
+    switch (logLevel) {
+      case TRACE:
+        loggerBuilder.setTraces(count);
+        break;
+      case DEBUG:
+        loggerBuilder.setDebugs(count);
+        break;
+      case INFO:
+        loggerBuilder.setInfos(count);
+        break;
+      case WARN:
+        loggerBuilder.setWarns(count);
+        break;
+      case ERROR:
+        loggerBuilder.setErrors(count);
+        break;
+    }
+
+    try {
+      loggerCountQueue.offer(loggerBuilder.build(), 10, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  static Prefab.Logger mergeLoggerCollection(Collection<Prefab.Logger> loggers) {
+    Iterator<Prefab.Logger> iter = loggers.iterator();
+    Prefab.Logger loggerToMutate = iter.next();
+    long traces = loggerToMutate.getTraces();
+    long debugs = loggerToMutate.getDebugs();
+    long infos = loggerToMutate.getInfos();
+    long warns = loggerToMutate.getWarns();
+    long errors = loggerToMutate.getErrors();
+
+    while (iter.hasNext()) {
+      Prefab.Logger logger = iter.next();
+      traces += logger.getTraces();
+      debugs += logger.getDebugs();
+      infos += logger.getInfos();
+      warns += logger.getWarns();
+      errors += logger.getErrors();
+    }
+
+    return loggerToMutate
+      .toBuilder()
+      .setTraces(traces)
+      .setDebugs(debugs)
+      .setInfos(infos)
+      .setWarns(warns)
+      .setErrors(errors)
+      .build();
+  }
+
+  static Prefab.Logger mergeLoggers(Prefab.Logger a, Prefab.Logger b) {
+    return a
+      .toBuilder()
+      .setTraces(a.getTraces() + b.getTraces())
+      .setDebugs(a.getDebugs() + b.getDebugs())
+      .setInfos(a.getInfos() + b.getInfos())
+      .setWarns(a.getWarns() + b.getWarns())
+      .setErrors(a.getErrors() + b.getErrors())
+      .build();
+  }
+
+  static class LogCounts {
+
+    private final long startTime;
+    private final Map<String, Prefab.Logger> loggerMap;
+
+    private final ReentrantLock mutex = new ReentrantLock();
+
+    LogCounts(long startTime) {
+      this.startTime = startTime;
+      loggerMap = new HashMap<>();
+    }
+
+    public long getStartTime() {
+      return startTime;
+    }
+
+    Map<String, Prefab.Logger> getLoggerMap() {
+      try {
+        mutex.lock();
+        return loggerMap;
+      } finally {
+        mutex.unlock();
+      }
+    }
+
+    void updateLoggerMap(Collection<Prefab.Logger> loggers) {
+      try {
+        mutex.lock();
+        for (Prefab.Logger logger : loggers) {
+          loggerMap.merge(
+            logger.getLoggerName(),
+            logger,
+            LoggerStatsAggregator::mergeLoggers
+          );
+        }
+      } finally {
+        mutex.unlock();
+      }
+    }
+  }
+}

--- a/client/src/test/java/cloud/prefab/client/internal/LoggerStatsAggregatorTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/LoggerStatsAggregatorTest.java
@@ -1,0 +1,96 @@
+package cloud.prefab.client.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import cloud.prefab.domain.Prefab;
+import java.time.Clock;
+import org.assertj.core.data.MapEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LoggerStatsAggregatorTest {
+
+  static final String LOGGER_A = "logger.a";
+  static final String LOGGER_B = "logger.b";
+
+  @Mock
+  Clock clock;
+
+  LoggerStatsAggregator instance;
+
+  @BeforeEach
+  void beforeEach() {
+    when(clock.millis()).thenReturn(1L, 2L, 3L);
+    instance = new LoggerStatsAggregator(clock);
+  }
+
+  @Test
+  void itAccumulates() {
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.TRACE, 1);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.TRACE, 2);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.DEBUG, 1);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.DEBUG, 1);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.DEBUG, 1);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.DEBUG, 4);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.INFO, 5);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.INFO, 6);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.WARN, 7);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.WARN, 8);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.ERROR, 9);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.ERROR, 10);
+
+    instance.reportLoggerUsage(LOGGER_B, Prefab.LogLevel.TRACE, 11);
+    instance.reportLoggerUsage(LOGGER_B, Prefab.LogLevel.ERROR, 12);
+
+    instance.aggregate(); // force intermediate accumulation
+
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.TRACE, 100);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.TRACE, 101);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.DEBUG, 200);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.DEBUG, 201);
+
+    instance.reportLoggerUsage(LOGGER_B, Prefab.LogLevel.TRACE, 50);
+    instance.reportLoggerUsage(LOGGER_B, Prefab.LogLevel.ERROR, 51);
+
+    instance.aggregate(); // force intermediate accumulation again
+
+    LoggerStatsAggregator.LogCounts counts = instance.getAndResetStats();
+
+    assertThat(counts.getStartTime()).isEqualTo(1L);
+    assertThat(counts.getLoggerMap())
+      .containsOnly(
+        MapEntry.entry(
+          LOGGER_A,
+          Prefab.Logger
+            .newBuilder()
+            .setLoggerName(LOGGER_A)
+            .setTraces(204)
+            .setDebugs(408)
+            .setInfos(11)
+            .setWarns(15)
+            .setErrors(19)
+            .build()
+        ),
+        MapEntry.entry(
+          LOGGER_B,
+          Prefab.Logger
+            .newBuilder()
+            .setLoggerName(LOGGER_B)
+            .setTraces(61)
+            .setDebugs(0)
+            .setInfos(0)
+            .setWarns(0)
+            .setErrors(63)
+            .build()
+        )
+      );
+    LoggerStatsAggregator.LogCounts moreCounts = instance.getAndResetStats();
+    assertThat(moreCounts.getStartTime()).isEqualTo(2);
+    assertThat(moreCounts.getLoggerMap()).isEmpty();
+  }
+}

--- a/client/src/test/java/cloud/prefab/client/internal/LoggerStatsAggregatorTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/LoggerStatsAggregatorTest.java
@@ -43,6 +43,8 @@ class LoggerStatsAggregatorTest {
     instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.WARN, 8);
     instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.ERROR, 9);
     instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.ERROR, 10);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.FATAL, 21);
+    instance.reportLoggerUsage(LOGGER_A, Prefab.LogLevel.FATAL, 22);
 
     instance.reportLoggerUsage(LOGGER_B, Prefab.LogLevel.TRACE, 11);
     instance.reportLoggerUsage(LOGGER_B, Prefab.LogLevel.ERROR, 12);
@@ -74,6 +76,7 @@ class LoggerStatsAggregatorTest {
             .setInfos(11)
             .setWarns(15)
             .setErrors(19)
+            .setFatals(43)
             .build()
         ),
         MapEntry.entry(
@@ -86,6 +89,7 @@ class LoggerStatsAggregatorTest {
             .setInfos(0)
             .setWarns(0)
             .setErrors(63)
+            .setFatals(0)
             .build()
         )
       );

--- a/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackConfigListener.java
+++ b/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackConfigListener.java
@@ -3,7 +3,6 @@ package cloud.prefab.client.config.logging;
 import ch.qos.logback.classic.Level;
 import cloud.prefab.client.config.ConfigChangeListener;
 import cloud.prefab.domain.Prefab.LogLevel;
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -19,16 +18,6 @@ public class LogbackConfigListener extends AbstractLoggingListener<Level> {
 
   private static final ConfigChangeListener INSTANCE = new LogbackConfigListener();
 
-  private static final Map<LogLevel, Level> LEVEL_MAP = ImmutableMap
-    .<LogLevel, Level>builder()
-    .put(LogLevel.FATAL, Level.ERROR)
-    .put(LogLevel.ERROR, Level.ERROR)
-    .put(LogLevel.WARN, Level.WARN)
-    .put(LogLevel.INFO, Level.INFO)
-    .put(LogLevel.DEBUG, Level.DEBUG)
-    .put(LogLevel.TRACE, Level.TRACE)
-    .build();
-
   public static ConfigChangeListener getInstance() {
     return INSTANCE;
   }
@@ -37,7 +26,7 @@ public class LogbackConfigListener extends AbstractLoggingListener<Level> {
 
   @Override
   protected Map<LogLevel, Level> getValidLevels() {
-    return LEVEL_MAP;
+    return LogbackLevelMapper.LEVEL_MAP;
   }
 
   @Override

--- a/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackLevelMapper.java
+++ b/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackLevelMapper.java
@@ -1,0 +1,28 @@
+package cloud.prefab.client.config.logging;
+
+import ch.qos.logback.classic.Level;
+import cloud.prefab.domain.Prefab;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+class LogbackLevelMapper {
+
+  static final Map<Prefab.LogLevel, Level> LEVEL_MAP = ImmutableMap
+    .<Prefab.LogLevel, Level>builder()
+    .put(Prefab.LogLevel.FATAL, Level.ERROR)
+    .put(Prefab.LogLevel.ERROR, Level.ERROR)
+    .put(Prefab.LogLevel.WARN, Level.WARN)
+    .put(Prefab.LogLevel.INFO, Level.INFO)
+    .put(Prefab.LogLevel.DEBUG, Level.DEBUG)
+    .put(Prefab.LogLevel.TRACE, Level.TRACE)
+    .build();
+
+  static final Map<Level, Prefab.LogLevel> REVERSE_LEVEL_MAP = ImmutableMap
+    .<Level, Prefab.LogLevel>builder()
+    .put(Level.ERROR, Prefab.LogLevel.ERROR)
+    .put(Level.WARN, Prefab.LogLevel.WARN)
+    .put(Level.INFO, Prefab.LogLevel.INFO)
+    .put(Level.DEBUG, Prefab.LogLevel.DEBUG)
+    .put(Level.TRACE, Prefab.LogLevel.TRACE)
+    .build();
+}

--- a/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackTurboFilter.java
+++ b/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackTurboFilter.java
@@ -40,6 +40,11 @@ public class LogbackTurboFilter extends TurboFilter {
     } else {
       recursionCheck.set(true);
     }
+    configClient.reportLoggerUsage(
+      logger.getName(),
+      LogbackLevelMapper.REVERSE_LEVEL_MAP.get(level),
+      1
+    );
 
     try {
       return FilterReply.NEUTRAL;

--- a/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackTurboFilter.java
+++ b/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackTurboFilter.java
@@ -1,0 +1,50 @@
+package cloud.prefab.client.config.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+import cloud.prefab.client.ConfigClient;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+
+public class LogbackTurboFilter extends TurboFilter {
+
+  private final ThreadLocal<Boolean> recursionCheck = ThreadLocal.withInitial(() -> false
+  );
+
+  private final ConfigClient configClient;
+
+  private LogbackTurboFilter(ConfigClient configClient) {
+    this.configClient = configClient;
+  }
+
+  public static void install(ConfigClient configClient) {
+    LogbackTurboFilter filter = new LogbackTurboFilter(configClient);
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+    loggerContext.addTurboFilter(filter);
+  }
+
+  @Override
+  public FilterReply decide(
+    Marker marker,
+    Logger logger,
+    Level level,
+    String s,
+    Object[] objects,
+    Throwable throwable
+  ) {
+    if (recursionCheck.get()) {
+      return FilterReply.NEUTRAL;
+    } else {
+      recursionCheck.set(true);
+    }
+
+    try {
+      return FilterReply.NEUTRAL;
+    } finally {
+      recursionCheck.set(false);
+    }
+  }
+}


### PR DESCRIPTION
This updates the client code to accept and report aggregated log message counts by level and logger name.
Adds a LogBackTurboFilter to report levels to the client

(we'll loop back to the other log backends after we've shaken the bugs out of the reporting and aggregation code in the entire system)