### PR TITLE
Add dynamic logback filter

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -63,6 +63,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.4.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <scope>test</scope>

--- a/client/src/main/java/cloud/prefab/client/ConfigClient.java
+++ b/client/src/main/java/cloud/prefab/client/ConfigClient.java
@@ -45,6 +45,8 @@ public interface ConfigClient {
     Map<String, String> properties
   );
 
+  boolean isReady();
+
   enum Source {
     REMOTE_API_GRPC,
     STREAMING,

--- a/client/src/main/java/cloud/prefab/client/ConfigClient.java
+++ b/client/src/main/java/cloud/prefab/client/ConfigClient.java
@@ -35,6 +35,16 @@ public interface ConfigClient {
 
   void reportLoggerUsage(String loggerName, Prefab.LogLevel logLevel, long count);
 
+  Optional<Prefab.LogLevel> getLogLevel(
+    String loggerName,
+    Map<String, Prefab.ConfigValue> properties
+  );
+
+  Optional<Prefab.LogLevel> getLogLevelFromStringMap(
+    String loggerName,
+    Map<String, String> properties
+  );
+
   enum Source {
     REMOTE_API_GRPC,
     STREAMING,

--- a/client/src/main/java/cloud/prefab/client/config/ConfigResolver.java
+++ b/client/src/main/java/cloud/prefab/client/config/ConfigResolver.java
@@ -1,6 +1,7 @@
 package cloud.prefab.client.config;
 
 import cloud.prefab.client.ConfigStore;
+import cloud.prefab.client.config.logging.AbstractLoggingListener;
 import cloud.prefab.domain.Prefab;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
@@ -47,7 +48,10 @@ public class ConfigResolver {
     Map<String, Prefab.ConfigValue> properties
   ) {
     if (!configStore.containsKey(key)) {
-      LOG.warn("No config value found for key {}", key);
+      // logging lookups generate a lot of misses so skip those
+      if (!key.startsWith(AbstractLoggingListener.LOG_LEVEL_PREFIX)) {
+        LOG.debug("No config value found for key {}", key);
+      }
       return Optional.empty();
     }
     final ConfigElement configElement = configStore.getElement(key);

--- a/client/src/main/java/cloud/prefab/client/config/ConfigResolver.java
+++ b/client/src/main/java/cloud/prefab/client/config/ConfigResolver.java
@@ -50,7 +50,7 @@ public class ConfigResolver {
     if (!configStore.containsKey(key)) {
       // logging lookups generate a lot of misses so skip those
       if (!key.startsWith(AbstractLoggingListener.LOG_LEVEL_PREFIX)) {
-        LOG.debug("No config value found for key {}", key);
+        LOG.trace("No config value found for key {}", key);
       }
       return Optional.empty();
     }

--- a/client/src/main/java/cloud/prefab/client/config/logging/TargetedLoggingHelper.java
+++ b/client/src/main/java/cloud/prefab/client/config/logging/TargetedLoggingHelper.java
@@ -1,0 +1,97 @@
+package cloud.prefab.client.config.logging;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import org.slf4j.MDC;
+
+/**
+ * Helper class to use targetted logging in projects that don't have logging MDC setup
+ * these helper methods will put data into the MDC for the duration of a runnable/callable
+ * then restore the original MDC data
+ */
+public class TargetedLoggingHelper {
+
+  /**
+   * Replaces the contents of the MDC context map while the specified runnable is running,
+   * then restores the MDC to original value
+   * @param context the contents of MDC while runnable is running
+   * @param runnable to run
+   */
+  public static void logWithExclusiveContext(
+    Map<String, String> context,
+    Runnable runnable
+  ) {
+    final Map<String, String> contextBackup = MDC.getCopyOfContextMap();
+    try {
+      MDC.setContextMap(context);
+      runnable.run();
+    } finally {
+      MDC.setContextMap(contextBackup);
+    }
+  }
+
+  /**
+   * Replaces the contents of the MDC context map while the specified runnable is running,
+   * then restores the MDC to original value
+   * @param context the contents of MDC while callable is running
+   * @param callable to call
+   * @return the return value of the callable
+   */
+  public static <T> T logWithExclusiveContext(
+    Map<String, String> context,
+    Callable<T> callable
+  ) throws Exception {
+    final Map<String, String> contextBackup = MDC.getCopyOfContextMap();
+    try {
+      MDC.setContextMap(context);
+      return callable.call();
+    } finally {
+      MDC.setContextMap(contextBackup);
+    }
+  }
+
+  /**
+   * Merges the provided context map into the MDC context map while the specified runnable is running,
+   * then restores MDC to original value
+   * @param context the contents of MDC while runnable is running
+   * @param runnable to run
+   */
+  public static void logWithMergedContext(
+    Map<String, String> context,
+    Runnable runnable
+  ) {
+    final Map<String, String> contextBackup = MDC.getCopyOfContextMap();
+    try {
+      mergeIntoMdc(context);
+      runnable.run();
+    } finally {
+      MDC.setContextMap(contextBackup);
+    }
+  }
+
+  /**
+   * Merges the provided context map into the MDC context map while the specified callable is running,
+   * then restores MDC to original value
+   * @param context the contents of MDC while callable is running
+   * @param callable to call
+   * @return the return value of the callable
+   */
+  public static <T> T logWithMergedContext(
+    Map<String, String> context,
+    Callable<T> callable
+  ) throws Exception {
+    final Map<String, String> contextBackup = MDC.getCopyOfContextMap();
+    try {
+      mergeIntoMdc(context);
+      return callable.call();
+    } finally {
+      MDC.setContextMap(contextBackup);
+    }
+  }
+
+  private static void mergeIntoMdc(Map<String, String> context) {
+    for (Map.Entry<String, String> entry : context.entrySet()) {
+      MDC.put(entry.getKey(), entry.getValue());
+    }
+  }
+}

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
@@ -241,6 +241,11 @@ public class ConfigClientImpl implements ConfigClient {
     );
   }
 
+  @Override
+  public boolean isReady() {
+    return initializedLatch.getCount() == 0;
+  }
+
   private Iterator<String> loggerNameLookupIterator(String loggerName) {
     return new Iterator<>() {
       String nextValue = AbstractLoggingListener.LOG_LEVEL_PREFIX + "." + loggerName;

--- a/client/src/test/java/cloud/prefab/client/ConfigClientImplTest.java
+++ b/client/src/test/java/cloud/prefab/client/ConfigClientImplTest.java
@@ -5,14 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import cloud.prefab.client.config.ConfigChangeEvent;
 import cloud.prefab.client.config.ConfigChangeListener;
+import cloud.prefab.client.config.TestData;
 import cloud.prefab.client.internal.ConfigClientImpl;
 import cloud.prefab.domain.Prefab;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
-class ConfigClientTest {
+class ConfigClientImplTest {
 
   @Test
   void localModeUnlocks() {
@@ -88,5 +90,66 @@ class ConfigClientTest {
           )
         )
       );
+  }
+
+  @Test
+  void itLooksUpLogLevelsViaStringMap() {
+    ConfigClient configClient = TestData
+      .clientWithEnv("logging_multilevel")
+      .configClient();
+
+    assertThat(
+      configClient.getLogLevelFromStringMap(
+        "com.example.p1.ClassOne",
+        Collections.emptyMap()
+      )
+    )
+      .contains(Prefab.LogLevel.TRACE);
+
+    assertThat(
+      configClient.getLogLevelFromStringMap(
+        "com.example.p1.ClassTwo",
+        Collections.emptyMap()
+      )
+    )
+      .contains(Prefab.LogLevel.DEBUG);
+
+    assertThat(
+      configClient.getLogLevelFromStringMap(
+        "com.example.AnotherClass",
+        Collections.emptyMap()
+      )
+    )
+      .contains(Prefab.LogLevel.ERROR);
+
+    assertThat(
+      configClient.getLogLevelFromStringMap("com.foo.ClipBoard", Collections.emptyMap())
+    )
+      .contains(Prefab.LogLevel.WARN);
+  }
+
+  @Test
+  void itLooksUpLogLevels() {
+    ConfigClient configClient = TestData
+      .clientWithEnv("logging_multilevel")
+      .configClient();
+
+    assertThat(
+      configClient.getLogLevel("com.example.p1.ClassOne", Collections.emptyMap())
+    )
+      .contains(Prefab.LogLevel.TRACE);
+
+    assertThat(
+      configClient.getLogLevel("com.example.p1.ClassTwo", Collections.emptyMap())
+    )
+      .contains(Prefab.LogLevel.DEBUG);
+
+    assertThat(
+      configClient.getLogLevel("com.example.AnotherClass", Collections.emptyMap())
+    )
+      .contains(Prefab.LogLevel.ERROR);
+
+    assertThat(configClient.getLogLevel("com.foo.ClipBoard", Collections.emptyMap()))
+      .contains(Prefab.LogLevel.WARN);
   }
 }

--- a/client/src/test/java/cloud/prefab/client/config/TestData.java
+++ b/client/src/test/java/cloud/prefab/client/config/TestData.java
@@ -1,0 +1,25 @@
+package cloud.prefab.client.config;
+
+import cloud.prefab.client.Options;
+import cloud.prefab.client.PrefabCloudClient;
+import java.util.List;
+
+public class TestData {
+
+  public static PrefabCloudClient clientWithSpecificLogLevel() {
+    return clientWithEnv("logging_specific");
+  }
+
+  public static PrefabCloudClient clientWithDefaultLogLevel() {
+    return clientWithEnv("logging_default");
+  }
+
+  public static PrefabCloudClient clientWithEnv(String envName) {
+    return new PrefabCloudClient(
+      new Options()
+        .setPrefabDatasource(Options.Datasources.LOCAL_ONLY)
+        .setConfigOverrideDir("src/test/resources/override_directory")
+        .setPrefabEnvs(List.of(envName))
+    );
+  }
+}

--- a/client/src/test/java/cloud/prefab/client/config/logging/LogLevelEventsTest.java
+++ b/client/src/test/java/cloud/prefab/client/config/logging/LogLevelEventsTest.java
@@ -2,12 +2,10 @@ package cloud.prefab.client.config.logging;
 
 import static org.mockito.Mockito.verify;
 
-import cloud.prefab.client.Options;
-import cloud.prefab.client.PrefabCloudClient;
+import cloud.prefab.client.config.TestData;
 import cloud.prefab.client.internal.ConfigClientImpl;
 import cloud.prefab.domain.Prefab;
 import com.google.common.collect.ImmutableMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -26,32 +24,14 @@ public class LogLevelEventsTest {
 
   @Test
   void itGetsSpecificLevelMessage() {
-    new ConfigClientImpl(clientWithSpecificLogLevel(), testListener);
+    new ConfigClientImpl(TestData.clientWithSpecificLogLevel(), testListener);
     verify(testListener).setLevel("test.logger", Optional.of(Level.WARNING));
   }
 
   @Test
   void itGetsDefaultLevelMessage() {
-    new ConfigClientImpl(clientWithDefaultLogLevel(), testListener);
+    new ConfigClientImpl(TestData.clientWithDefaultLogLevel(), testListener);
     verify(testListener).setDefaultLevel(Optional.of(Level.WARNING));
-  }
-
-  protected PrefabCloudClient clientWithSpecificLogLevel() {
-    return new PrefabCloudClient(
-      new Options()
-        .setPrefabDatasource(Options.Datasources.LOCAL_ONLY)
-        .setConfigOverrideDir("src/test/resources/override_directory")
-        .setPrefabEnvs(List.of("logging_specific"))
-    );
-  }
-
-  protected PrefabCloudClient clientWithDefaultLogLevel() {
-    return new PrefabCloudClient(
-      new Options()
-        .setPrefabDatasource(Options.Datasources.LOCAL_ONLY)
-        .setConfigOverrideDir("src/test/resources/override_directory")
-        .setPrefabEnvs(List.of("logging_default"))
-    );
   }
 
   private static class TestListener extends AbstractLoggingListener {

--- a/client/src/test/java/cloud/prefab/client/config/logging/TargetedLoggingHelperTest.java
+++ b/client/src/test/java/cloud/prefab/client/config/logging/TargetedLoggingHelperTest.java
@@ -1,0 +1,185 @@
+package cloud.prefab.client.config.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+class TargetedLoggingHelperTest {
+
+  // Note this won't work unless a logging backend is installed
+
+  Logger LOG = LoggerFactory.getLogger(TargetedLoggingHelperTest.class);
+
+  @AfterEach
+  void afterEach() {
+    MDC.clear();
+  }
+
+  @Test
+  void itRunsRunnableWithExclusiveMdcStartingBlank() {
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+
+    Map<String, String> newContext = Map.of("portalId", "53", "userId", "abc123");
+
+    TargetedLoggingHelper.logWithExclusiveContext(
+      newContext,
+      () -> {
+        assertThat(MDC.getCopyOfContextMap()).isEqualTo(newContext);
+      }
+    );
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+  }
+
+  @Test
+  void itRunsRunnableWithExclusiveMdcStartingWithContent() {
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+    Map<String, String> starterContext = Map.of("foo", "bar", "something", "else");
+    for (Map.Entry<String, String> entry : starterContext.entrySet()) {
+      MDC.put(entry.getKey(), entry.getValue());
+    }
+
+    Map<String, String> newContext = Map.of("portalId", "53", "userId", "abc123");
+
+    TargetedLoggingHelper.logWithExclusiveContext(
+      newContext,
+      () -> {
+        assertThat(MDC.getCopyOfContextMap()).isEqualTo(newContext);
+      }
+    );
+    assertThat(MDC.getCopyOfContextMap()).isEqualTo(starterContext);
+  }
+
+  @Test
+  void itCallsCallableWithExclusiveMdcStartingBlank() throws Exception {
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+
+    Map<String, String> newContext = Map.of("portalId", "53", "userId", "abc123");
+
+    assertThat(
+      TargetedLoggingHelper.logWithExclusiveContext(
+        newContext,
+        () -> {
+          assertThat(MDC.getCopyOfContextMap()).isEqualTo(newContext);
+          return 127;
+        }
+      )
+    )
+      .isEqualTo(127);
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+  }
+
+  @Test
+  void itCallsCallableWithExclusiveMdcStartingWithContent() throws Exception {
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+    Map<String, String> starterContext = Map.of("foo", "bar", "something", "else");
+    for (Map.Entry<String, String> entry : starterContext.entrySet()) {
+      MDC.put(entry.getKey(), entry.getValue());
+    }
+
+    Map<String, String> newContext = Map.of("portalId", "53", "userId", "abc123");
+
+    assertThat(
+      TargetedLoggingHelper.logWithExclusiveContext(
+        newContext,
+        () -> {
+          assertThat(MDC.getCopyOfContextMap()).isEqualTo(newContext);
+          return 127;
+        }
+      )
+    )
+      .isEqualTo(127);
+    assertThat(MDC.getCopyOfContextMap()).isEqualTo(starterContext);
+  }
+
+  @Test
+  void itRunsRunnableWithMergedMdcStartingBlank() {
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+
+    Map<String, String> newContext = Map.of("portalId", "53", "userId", "abc123");
+
+    TargetedLoggingHelper.logWithMergedContext(
+      newContext,
+      () -> {
+        assertThat(MDC.getCopyOfContextMap()).isEqualTo(newContext);
+      }
+    );
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+  }
+
+  @Test
+  void itRunsRunnableWithMergedMdcStartingWithContent() {
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+    Map<String, String> starterContext = Map.of("foo", "bar", "something", "else");
+    for (Map.Entry<String, String> entry : starterContext.entrySet()) {
+      MDC.put(entry.getKey(), entry.getValue());
+    }
+
+    Map<String, String> newContext = Map.of("portalId", "53", "userId", "abc123");
+
+    TargetedLoggingHelper.logWithMergedContext(
+      newContext,
+      () -> {
+        assertThat(MDC.getCopyOfContextMap())
+          .isEqualTo(mergeMaps(starterContext, newContext));
+      }
+    );
+    assertThat(MDC.getCopyOfContextMap()).isEqualTo(starterContext);
+  }
+
+  @Test
+  void itCallsCallableWithMergedMdcStartingBlank() throws Exception {
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+
+    Map<String, String> newContext = Map.of("portalId", "53", "userId", "abc123");
+
+    assertThat(
+      TargetedLoggingHelper.logWithMergedContext(
+        newContext,
+        () -> {
+          assertThat(MDC.getCopyOfContextMap()).isEqualTo(newContext);
+          return 127;
+        }
+      )
+    )
+      .isEqualTo(127);
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+  }
+
+  @Test
+  void itCallsCallableWithMergedMdcStartingWithContent() throws Exception {
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+    Map<String, String> starterContext = Map.of("foo", "bar", "something", "else");
+    for (Map.Entry<String, String> entry : starterContext.entrySet()) {
+      MDC.put(entry.getKey(), entry.getValue());
+    }
+
+    Map<String, String> newContext = Map.of("portalId", "53", "userId", "abc123");
+
+    assertThat(
+      TargetedLoggingHelper.logWithMergedContext(
+        newContext,
+        () -> {
+          assertThat(MDC.getCopyOfContextMap())
+            .isEqualTo(mergeMaps(starterContext, newContext));
+          return 127;
+        }
+      )
+    )
+      .isEqualTo(127);
+    assertThat(MDC.getCopyOfContextMap()).isEqualTo(starterContext);
+  }
+
+  Map<String, String> mergeMaps(Map<String, String> first, Map<String, String> second) {
+    return ImmutableMap
+      .<String, String>builder()
+      .putAll(first)
+      .putAll(second)
+      .buildKeepingLast();
+  }
+}

--- a/client/src/test/resources/override_directory/.prefab.logging_multilevel.config.yaml
+++ b/client/src/test/resources/override_directory/.prefab.logging_multilevel.config.yaml
@@ -1,0 +1,5 @@
+log-level: WARN
+log-level.com.example: ERROR
+log-level.com.example.p1: DEBUG
+log-level.com.example.p1.ClassOne: TRACE
+log-level.com.example.p2: INFO

--- a/logback-listener/pom.xml
+++ b/logback-listener/pom.xml
@@ -62,6 +62,16 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackTurboFilter.java
+++ b/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackTurboFilter.java
@@ -6,7 +6,12 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.core.spi.FilterReply;
 import cloud.prefab.client.ConfigClient;
+import cloud.prefab.domain.Prefab;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.slf4j.Marker;
 
 public class LogbackTurboFilter extends TurboFilter {
@@ -16,7 +21,7 @@ public class LogbackTurboFilter extends TurboFilter {
 
   private final ConfigClient configClient;
 
-  private LogbackTurboFilter(ConfigClient configClient) {
+  LogbackTurboFilter(ConfigClient configClient) {
     this.configClient = configClient;
   }
 
@@ -47,6 +52,20 @@ public class LogbackTurboFilter extends TurboFilter {
     );
 
     try {
+      Map<String, String> mdcData = MDC.getCopyOfContextMap();
+      Optional<Prefab.LogLevel> loglevelMaybe = configClient.getLogLevelFromStringMap(
+        logger.getName(),
+        mdcData != null ? mdcData : new HashMap<>()
+      );
+      if (loglevelMaybe.isPresent()) {
+        Level calculatedMinLogLevelToAccept = LogbackLevelMapper.LEVEL_MAP.get(
+          loglevelMaybe.get()
+        );
+        if (level.isGreaterOrEqual(calculatedMinLogLevelToAccept)) {
+          return FilterReply.ACCEPT;
+        }
+        return FilterReply.DENY;
+      }
       return FilterReply.NEUTRAL;
     } finally {
       recursionCheck.set(false);

--- a/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackTurboFilter.java
+++ b/logback-listener/src/main/java/cloud/prefab/client/config/logging/LogbackTurboFilter.java
@@ -40,6 +40,9 @@ public class LogbackTurboFilter extends TurboFilter {
     Object[] objects,
     Throwable throwable
   ) {
+    if (!configClient.isReady()) {
+      return FilterReply.NEUTRAL;
+    }
     if (recursionCheck.get()) {
       return FilterReply.NEUTRAL;
     } else {

--- a/logback-listener/src/test/java/cloud/prefab/client/config/logging/LogbackTurboFilterTest.java
+++ b/logback-listener/src/test/java/cloud/prefab/client/config/logging/LogbackTurboFilterTest.java
@@ -102,19 +102,23 @@ class LogbackTurboFilterTest {
 
     Map<String, String> contextData = Map.of("key1", "val1", "key2", "val2");
 
-    MDC.setContextMap(contextData);
+    try {
+      MDC.setContextMap(contextData);
 
-    Mockito
-      .when(configClient.getLogLevelFromStringMap(logger.getName(), contextData))
-      .thenReturn(Optional.of(Prefab.LogLevel.DEBUG));
+      Mockito
+        .when(configClient.getLogLevelFromStringMap(logger.getName(), contextData))
+        .thenReturn(Optional.of(Prefab.LogLevel.DEBUG));
 
-    assertThat(
-      logbackTurboFilter.decide(null, logger, Level.DEBUG, "", new Object[0], null)
-    )
-      .isEqualTo(FilterReply.ACCEPT);
+      assertThat(
+        logbackTurboFilter.decide(null, logger, Level.DEBUG, "", new Object[0], null)
+      )
+        .isEqualTo(FilterReply.ACCEPT);
 
-    Mockito
-      .verify(configClient)
-      .reportLoggerUsage(logger.getName(), Prefab.LogLevel.DEBUG, 1);
+      Mockito
+        .verify(configClient)
+        .reportLoggerUsage(logger.getName(), Prefab.LogLevel.DEBUG, 1);
+    } finally {
+      MDC.clear();
+    }
   }
 }

--- a/logback-listener/src/test/java/cloud/prefab/client/config/logging/LogbackTurboFilterTest.java
+++ b/logback-listener/src/test/java/cloud/prefab/client/config/logging/LogbackTurboFilterTest.java
@@ -1,0 +1,120 @@
+package cloud.prefab.client.config.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.core.spi.FilterReply;
+import cloud.prefab.client.ConfigClient;
+import cloud.prefab.domain.Prefab;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+@ExtendWith(MockitoExtension.class)
+class LogbackTurboFilterTest {
+
+  @Mock
+  ConfigClient configClient;
+
+  @InjectMocks
+  LogbackTurboFilter logbackTurboFilter;
+
+  @Test
+  void itReportsLoggingAndAsksForLogLevelReturnsNeutral() {
+    Logger logger = (Logger) LoggerFactory.getLogger(
+      "com.example.factory.FactoryFactory"
+    );
+
+    Mockito
+      .when(
+        configClient.getLogLevelFromStringMap(logger.getName(), Collections.emptyMap())
+      )
+      .thenReturn(Optional.empty());
+
+    assertThat(
+      logbackTurboFilter.decide(null, logger, Level.DEBUG, "", new Object[0], null)
+    )
+      .isEqualTo(FilterReply.NEUTRAL);
+
+    Mockito
+      .verify(configClient)
+      .reportLoggerUsage(logger.getName(), Prefab.LogLevel.DEBUG, 1);
+  }
+
+  @Test
+  void itReportsLoggingAndAsksForLogLevelReturnsAccept() {
+    Logger logger = (Logger) LoggerFactory.getLogger(
+      "com.example.factory.FactoryFactory"
+    );
+
+    Mockito
+      .when(
+        configClient.getLogLevelFromStringMap(logger.getName(), Collections.emptyMap())
+      )
+      .thenReturn(Optional.of(Prefab.LogLevel.DEBUG));
+
+    assertThat(
+      logbackTurboFilter.decide(null, logger, Level.DEBUG, "", new Object[0], null)
+    )
+      .isEqualTo(FilterReply.ACCEPT);
+
+    Mockito
+      .verify(configClient)
+      .reportLoggerUsage(logger.getName(), Prefab.LogLevel.DEBUG, 1);
+  }
+
+  @Test
+  void itReportsLoggingAndAsksForLogLevelReturnsDeny() {
+    Logger logger = (Logger) LoggerFactory.getLogger(
+      "com.example.factory.FactoryFactory"
+    );
+
+    Mockito
+      .when(
+        configClient.getLogLevelFromStringMap(logger.getName(), Collections.emptyMap())
+      )
+      .thenReturn(Optional.of(Prefab.LogLevel.WARN));
+
+    assertThat(
+      logbackTurboFilter.decide(null, logger, Level.DEBUG, "", new Object[0], null)
+    )
+      .isEqualTo(FilterReply.DENY);
+
+    Mockito
+      .verify(configClient)
+      .reportLoggerUsage(logger.getName(), Prefab.LogLevel.DEBUG, 1);
+  }
+
+  @Test
+  void itSendsAvailableMdcData() {
+    Logger logger = (Logger) LoggerFactory.getLogger(
+      "com.example.factory.FactoryFactory"
+    );
+
+    Map<String, String> contextData = Map.of("key1", "val1", "key2", "val2");
+
+    MDC.setContextMap(contextData);
+
+    Mockito
+      .when(configClient.getLogLevelFromStringMap(logger.getName(), contextData))
+      .thenReturn(Optional.of(Prefab.LogLevel.DEBUG));
+
+    assertThat(
+      logbackTurboFilter.decide(null, logger, Level.DEBUG, "", new Object[0], null)
+    )
+      .isEqualTo(FilterReply.ACCEPT);
+
+    Mockito
+      .verify(configClient)
+      .reportLoggerUsage(logger.getName(), Prefab.LogLevel.DEBUG, 1);
+  }
+}


### PR DESCRIPTION
This extends the logback TurboFilter to look up loglevels based on not only the logger name, but the contents of the Mapped Diagnostic Context.
Undecided if the TurboFilter should also install the Listener to set log levels that aren't conditional in anyway - would be nice at least for prefab's logging needs to do that otherwise they may not get logged at all due to the re-entrancy check 