### PR TITLE
Connectivity test and http fallback for logger stats

### DIFF
--- a/client/src/main/java/cloud/prefab/client/ClientAuthenticationInterceptor.java
+++ b/client/src/main/java/cloud/prefab/client/ClientAuthenticationInterceptor.java
@@ -1,6 +1,7 @@
 package cloud.prefab.client;
 
 import cloud.prefab.client.util.MavenInfo;
+import cloud.prefab.domain.GreetingServiceGrpc;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -9,20 +10,24 @@ import io.grpc.ForwardingClientCall;
 import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import java.util.Set;
 
 public class ClientAuthenticationInterceptor implements ClientInterceptor {
 
-  public static final Metadata.Key<String> CUSTOM_HEADER_KEY = Metadata.Key.of(
-    "auth",
+  public static final String CUSTOM_HEADER_KEY = "auth";
+  public static final Metadata.Key<String> CUSTOM_HEADER_METADATA_KEY = Metadata.Key.of(
+    CUSTOM_HEADER_KEY,
     Metadata.ASCII_STRING_MARSHALLER
   );
 
-  public static final Metadata.Key<String> CLIENT_HEADER_KEY = Metadata.Key.of(
+  public static final String CLIENT_HEADER_KEY = "client";
+
+  public static final Metadata.Key<String> CLIENT_HEADER_METADATA_KEY = Metadata.Key.of(
     "client",
     Metadata.ASCII_STRING_MARSHALLER
   );
 
-  private static final String CLIENT_HEADER_VALUE = String.format(
+  public static final String CLIENT_HEADER_VALUE = String.format(
     "%s.%s",
     MavenInfo.getInstance().getArtifactId(),
     MavenInfo.getInstance().getVersion()
@@ -34,21 +39,27 @@ public class ClientAuthenticationInterceptor implements ClientInterceptor {
     this.apikey = apikey;
   }
 
+  private static final Set<String> NO_AUTH_SERVICE_NAMES = Set.of(
+    GreetingServiceGrpc.SERVICE_NAME
+  );
+
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
     MethodDescriptor<ReqT, RespT> methodDescriptor,
     CallOptions callOptions,
     Channel channel
   ) {
-    return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+    return new ForwardingClientCall.SimpleForwardingClientCall<>(
       channel.newCall(methodDescriptor, callOptions)
     ) {
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
-        headers.put(CLIENT_HEADER_KEY, CLIENT_HEADER_VALUE);
-        headers.put(CUSTOM_HEADER_KEY, apikey);
+        headers.put(CLIENT_HEADER_METADATA_KEY, CLIENT_HEADER_VALUE);
+        if (!NO_AUTH_SERVICE_NAMES.contains(methodDescriptor.getServiceName())) {
+          headers.put(CUSTOM_HEADER_METADATA_KEY, apikey);
+        }
         super.start(
-          new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
+          new ForwardingClientCallListener.SimpleForwardingClientCallListener<>(
             responseListener
           ) {},
           headers

--- a/client/src/main/java/cloud/prefab/client/Options.java
+++ b/client/src/main/java/cloud/prefab/client/Options.java
@@ -35,6 +35,8 @@ public class Options {
 
   private boolean reportLogStats = true;
 
+  private boolean grpcEnabled = true;
+
   public Options() {
     this.apikey = System.getenv("PREFAB_API_KEY");
     this.prefabGrpcUrl =
@@ -182,5 +184,14 @@ public class Options {
     envs.add(DEFAULT_ENV);
     envs.addAll(prefabEnvs);
     return envs;
+  }
+
+  public boolean isGrpcEnabled() {
+    return grpcEnabled;
+  }
+
+  public Options setGrpcEnabled(boolean grpcEnabled) {
+    this.grpcEnabled = grpcEnabled;
+    return this;
   }
 }

--- a/client/src/main/java/cloud/prefab/client/Options.java
+++ b/client/src/main/java/cloud/prefab/client/Options.java
@@ -194,4 +194,8 @@ public class Options {
     this.grpcEnabled = grpcEnabled;
     return this;
   }
+
+  public String getApiKeyId() {
+    return getApikey().split("\\-")[0];
+  }
 }

--- a/client/src/main/java/cloud/prefab/client/PrefabCloudClient.java
+++ b/client/src/main/java/cloud/prefab/client/PrefabCloudClient.java
@@ -32,9 +32,7 @@ public class PrefabCloudClient implements AutoCloseable {
       if (options.getApikey() == null || options.getApikey().isEmpty()) {
         throw new RuntimeException("PREFAB_API_KEY not set");
       }
-
-      long apiKeyId = Long.parseLong(options.getApikey().split("\\-")[0]);
-      LOG.info("Initializing Prefab for apiKeyId {}", apiKeyId);
+      LOG.info("Initializing Prefab for apiKeyId {}", options.getApiKeyId());
     }
 
     this.closed = new AtomicBoolean(false);

--- a/client/src/main/java/cloud/prefab/client/internal/ConnectivityTester.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConnectivityTester.java
@@ -1,0 +1,99 @@
+package cloud.prefab.client.internal;
+
+import cloud.prefab.client.Options;
+import cloud.prefab.domain.GreetingServiceGrpc;
+import cloud.prefab.domain.Prefab;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ConnectivityTester {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectivityTester.class);
+  private final GreetingServiceGrpc.GreetingServiceFutureStub greetingServiceFutureStub;
+  private final HttpClient httpClient;
+  private final Options options;
+
+  ConnectivityTester(
+    GreetingServiceGrpc.GreetingServiceFutureStub greetingServiceFutureStub,
+    HttpClient httpClient,
+    Options options
+  ) {
+    this.greetingServiceFutureStub = greetingServiceFutureStub;
+    this.httpClient = httpClient;
+    this.options = options;
+  }
+
+  public boolean testGrpc() {
+    int attempts = 4;
+    try {
+      int attempt = 1;
+      while (attempt < attempts) {
+        String uniqueGreeting = UUID.randomUUID().toString();
+        try {
+          ListenableFuture<Prefab.GreetingResponse> responseFuture = greetingServiceFutureStub.greet(
+            Prefab.GreetingMessage.newBuilder().setGreeting(uniqueGreeting).build()
+          );
+          responseFuture.get(5, TimeUnit.SECONDS);
+          LOG.info("GRPC connection check succeeded");
+          return true;
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        attempt++;
+      }
+      LOG.info("Attempts to reach GRPC connectivity test exhausted");
+    } catch (TimeoutException e) {
+      LOG.info("Timeout while attempting to reach GRPC connectivity test service");
+      return false;
+    } catch (ExecutionException e) {
+      LOG.info(
+        "Error while performing GRPC connectivity test {} (DEBUG for stacktrace)",
+        e.getCause().getMessage()
+      );
+      LOG.debug("Error while performing GRPC connectivity test", e.getCause());
+    }
+    return false;
+  }
+
+  public boolean testHttps() {
+    HttpRequest request = HttpRequest
+      .newBuilder()
+      .uri(URI.create(options.getPrefabApiUrl() + "/hello"))
+      .build();
+    try {
+      HttpResponse<Void> response = httpClient.send(
+        request,
+        HttpResponse.BodyHandlers.discarding()
+      );
+      if (PrefabHttpClient.isSuccess(response.statusCode())) {
+        LOG.info("HTTP connection check succeeded");
+        return true;
+      } else {
+        LOG.info(
+          "HTTP connection to {} failed with response code {}",
+          request.uri(),
+          response.statusCode()
+        );
+      }
+    } catch (IOException e) {
+      LOG.info(
+        "HTTP connection to {} failed with IO exception {}",
+        request.uri(),
+        e.getMessage()
+      );
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    return false;
+  }
+}

--- a/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
+++ b/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
@@ -1,0 +1,70 @@
+package cloud.prefab.client.internal;
+
+import cloud.prefab.client.ClientAuthenticationInterceptor;
+import cloud.prefab.client.Options;
+import cloud.prefab.domain.Prefab;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PrefabHttpClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PrefabHttpClient.class);
+  private static final String PROTO_MEDIA_TYPE = "application/x-protobuf";
+
+  private final Options options;
+  private final HttpClient httpClient;
+
+  PrefabHttpClient(HttpClient httpClient, Options options) {
+    this.httpClient = httpClient;
+    this.options = options;
+  }
+
+  void reportLoggers(Prefab.Loggers loggers) {
+    HttpRequest request = HttpRequest
+      .newBuilder()
+      .header(
+        ClientAuthenticationInterceptor.CLIENT_HEADER_KEY,
+        ClientAuthenticationInterceptor.CLIENT_HEADER_VALUE
+      )
+      .header(ClientAuthenticationInterceptor.CUSTOM_HEADER_KEY, options.getApikey())
+      .header("Content-Type", PROTO_MEDIA_TYPE)
+      .header("Accept", PROTO_MEDIA_TYPE)
+      .header(
+        "Authorization",
+        getBasicAuthenticationHeader("ignored", options.getApikey())
+      )
+      .uri(URI.create(options.getPrefabApiUrl() + "/api/v1/known-loggers"))
+      .POST(HttpRequest.BodyPublishers.ofByteArray(loggers.toByteArray()))
+      .build();
+    try {
+      HttpResponse<Void> response = httpClient.send(
+        request,
+        HttpResponse.BodyHandlers.discarding()
+      );
+
+      if (!isSuccess(response.statusCode())) {
+        LOG.info("Uploading logger stats returned code {}", response.statusCode());
+      }
+    } catch (IOException e) {
+      LOG.warn("Error uploading logger stats via http {}", e.getMessage());
+    } catch (InterruptedException e) {
+      LOG.warn("Interrupted while uploading logger stats via http");
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  static boolean isSuccess(int statusCode) {
+    return statusCode >= 200 && statusCode < 300;
+  }
+
+  private String getBasicAuthenticationHeader(String username, String password) {
+    String valueToEncode = username + ":" + password;
+    return "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
+  }
+}

--- a/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
+++ b/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
@@ -37,7 +37,7 @@ public class PrefabHttpClient {
       .header("Accept", PROTO_MEDIA_TYPE)
       .header(
         "Authorization",
-        getBasicAuthenticationHeader("ignored", options.getApikey())
+        getBasicAuthenticationHeader(options.getApiKeyId(), options.getApikey())
       )
       .uri(URI.create(options.getPrefabApiUrl() + "/api/v1/known-loggers"))
       .POST(HttpRequest.BodyPublishers.ofByteArray(loggers.toByteArray()))
@@ -49,7 +49,7 @@ public class PrefabHttpClient {
       );
 
       if (!isSuccess(response.statusCode())) {
-        LOG.info("Uploading logger stats returned code {}", response.statusCode());
+        LOG.debug("Uploading logger stats returned code {}", response.statusCode());
       }
     } catch (IOException e) {
       LOG.warn("Error uploading logger stats via http {}", e.getMessage());


### PR DESCRIPTION
This updates the client to check that prefab can be reached over http and/or grpc. If grpc does not work then attempts to use grpc are disabled.
Adds a http api client for logger stats

Future work: add an SSE implementation as a fallback for the GRPC streaming - a client unable to use GRPC will fall back to minutely-polling of the CDN