### PR TITLE
add time range support

### DIFF
--- a/client/src/main/java/cloud/prefab/client/config/ConfigResolver.java
+++ b/client/src/main/java/cloud/prefab/client/config/ConfigResolver.java
@@ -255,6 +255,19 @@ public class ConfigResolver {
     switch (criterion.getOperator()) {
       case ALWAYS_TRUE:
         return List.of(new EvaluatedCriterion(criterion, true));
+      case IN_TIME_RANGE:
+        if (prop.isEmpty() || !criterion.getValueToMatch().hasTimeRange()) {
+          return List.of(new EvaluatedCriterion(criterion, false));
+        }
+        long currentTime = prop.get().getInt();
+        Prefab.TimeRange timeRange = criterion.getValueToMatch().getTimeRange();
+        if (timeRange.hasStart() && currentTime < timeRange.getStart()) {
+          return List.of(new EvaluatedCriterion(criterion, false));
+        }
+        if (timeRange.hasEnd() && currentTime > timeRange.getEnd()) {
+          return List.of(new EvaluatedCriterion(criterion, false));
+        }
+        return List.of(new EvaluatedCriterion(criterion, true));
       case HIERARCHICAL_MATCH:
         if (prop.isPresent()) {
           if (prop.get().hasString() && criterion.getValueToMatch().hasString()) {


### PR DESCRIPTION
See the linked proto change that adds TimeRange message and IN_TIME_RANGE operator
we'd auto populate a prefab namespace so that prefab.current-time-millis had the current time

in ruby we'd construct one of these like this

```
  Prefab::ConditionalValue.new(value: Prefab::ConfigValue.new(bool: true),
                                                            criteria: [
                                                              Prefab::Criterion.new(
                                                                value_to_match: Prefab::ConfigValue.new(time_range: Prefab::TimeRange.new(after: 1682899200000)),
                                                                operator: Prefab::Criterion::CriterionOperator::IN_TIME_RANGE,
                                                                property_name: "prefab.current-time-millis"
                                                              )]),

```