### PR TITLE
Updates for integration tests 0.2.1

### DIFF
--- a/client/src/main/java/cloud/prefab/client/config/ConfigValueUtils.java
+++ b/client/src/main/java/cloud/prefab/client/config/ConfigValueUtils.java
@@ -57,4 +57,27 @@ public class ConfigValueUtils {
         return Optional.empty();
     }
   }
+
+  public static Optional<Object> asObject(Prefab.ConfigValue configValue) {
+    switch (configValue.getTypeCase()) {
+      case STRING:
+        return Optional.of(configValue.getString());
+      case DOUBLE:
+        return Optional.of(configValue.getDouble());
+      case INT:
+        return Optional.of(configValue.getInt());
+      case BOOL:
+        return Optional.of(configValue.getBool());
+      case LOG_LEVEL:
+        return Optional.of(configValue.getLogLevel());
+      case STRING_LIST:
+        return Optional.of(configValue.getStringList().getValuesList());
+      default:
+        LOG.debug(
+          "Encountered unexpected type {} of configValue to coerce to string",
+          configValue.getTypeCase()
+        );
+        return Optional.empty();
+    }
+  }
 }

--- a/client/src/main/java/cloud/prefab/client/internal/HashProvider.java
+++ b/client/src/main/java/cloud/prefab/client/internal/HashProvider.java
@@ -1,0 +1,23 @@
+package cloud.prefab.client.internal;
+
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.UnsignedInts;
+import java.nio.charset.StandardCharsets;
+
+public interface HashProvider {
+  long UNSIGNED_INT_MAX = Integer.MAX_VALUE + (long) Integer.MAX_VALUE;
+
+  /**
+   * Maps a string argument onto the space 0..1 using Hashing.murmur3_32_fixed()
+   * @param string
+   * @return
+   */
+  default double hash(String string) {
+    long value = UnsignedInts.toLong(
+      Hashing.murmur3_32_fixed().hashString(string, StandardCharsets.UTF_8).asInt()
+    );
+    return value / (double) UNSIGNED_INT_MAX;
+  }
+
+  HashProvider DEFAULT = new HashProvider() {};
+}

--- a/client/src/main/java/cloud/prefab/client/internal/WeightedValueEvaluator.java
+++ b/client/src/main/java/cloud/prefab/client/internal/WeightedValueEvaluator.java
@@ -8,7 +8,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.Optional;
 
-
 public class WeightedValueEvaluator {
 
   private final HashProvider hashProvider;

--- a/client/src/main/java/cloud/prefab/client/internal/WeightedValueEvaluator.java
+++ b/client/src/main/java/cloud/prefab/client/internal/WeightedValueEvaluator.java
@@ -5,29 +5,24 @@ import cloud.prefab.client.util.RandomProvider;
 import cloud.prefab.client.util.RandomProviderIF;
 import cloud.prefab.domain.Prefab;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.hash.HashCode;
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 
+
 public class WeightedValueEvaluator {
 
-  public static final long UNSIGNED_INT_MAX =
-    Integer.MAX_VALUE + (long) Integer.MAX_VALUE;
-  private final HashFunction hashFunction;
+  private final HashProvider hashProvider;
 
   private final RandomProviderIF randomProvider;
 
   public WeightedValueEvaluator() {
-    this(new RandomProvider(), Hashing.murmur3_32_fixed());
+    this(new RandomProvider(), HashProvider.DEFAULT);
   }
 
   @VisibleForTesting
-  WeightedValueEvaluator(RandomProviderIF randomProvider, HashFunction hashFunction) {
+  WeightedValueEvaluator(RandomProviderIF randomProvider, HashProvider hashProvider) {
     this.randomProvider = randomProvider;
-    this.hashFunction = hashFunction;
+    this.hashProvider = hashProvider;
   }
 
   public Prefab.ConfigValue toValue(
@@ -44,7 +39,7 @@ public class WeightedValueEvaluator {
     double pctThroughDistribution = hashPropertyValue
       .map(s -> getUserPct(featureName, s))
       .orElseGet(randomProvider::random);
-    return getVariantIdxFromWeights(
+    return getValueFromWeightsAndPercent(
       weightedValues.getWeightedValuesList(),
       pctThroughDistribution
     );
@@ -61,7 +56,7 @@ public class WeightedValueEvaluator {
     return Optional.empty();
   }
 
-  private Prefab.ConfigValue getVariantIdxFromWeights(
+  private Prefab.ConfigValue getValueFromWeightsAndPercent(
     List<Prefab.WeightedValue> weightedValues,
     double targetPctThroughDistribution
   ) {
@@ -84,12 +79,6 @@ public class WeightedValueEvaluator {
 
   private double getUserPct(String featureName, String configValue) {
     final String toHash = featureName + configValue;
-    final HashCode hashCode = hashFunction.hashString(toHash, StandardCharsets.UTF_8);
-    return pct(hashCode.asInt());
-  }
-
-  private double pct(int signedInt) {
-    long y = (long) signedInt + Integer.MAX_VALUE;
-    return y / (double) (UNSIGNED_INT_MAX);
+    return hashProvider.hash(toHash);
   }
 }

--- a/client/src/main/java/cloud/prefab/client/value/LiveObject.java
+++ b/client/src/main/java/cloud/prefab/client/value/LiveObject.java
@@ -1,0 +1,18 @@
+package cloud.prefab.client.value;
+
+import cloud.prefab.client.ConfigClient;
+import cloud.prefab.client.config.ConfigValueUtils;
+import cloud.prefab.domain.Prefab;
+import java.util.Optional;
+
+public class LiveObject extends AbstractLiveValue<Object> {
+
+  public LiveObject(ConfigClient configClient, String key) {
+    super(configClient, key);
+  }
+
+  @Override
+  public Optional<Object> resolve(Prefab.ConfigValue value) {
+    return ConfigValueUtils.asObject(value);
+  }
+}

--- a/client/src/test/java/cloud/prefab/client/integration/IntegrationTestFunction.java
+++ b/client/src/test/java/cloud/prefab/client/integration/IntegrationTestFunction.java
@@ -11,15 +11,15 @@ import java.util.stream.Collectors;
 public enum IntegrationTestFunction {
   GET_OR_RAISE("get_or_raise") {
     @Override
-    public String apply(PrefabCloudClient client, IntegrationTestInput input) {
+    public Object apply(PrefabCloudClient client, IntegrationTestInput input) {
       return input.getWithoutFallback(client);
     }
   },
   GET("get") {
     @Override
-    public String apply(PrefabCloudClient client, IntegrationTestInput input) {
+    public Object apply(PrefabCloudClient client, IntegrationTestInput input) {
       if (input.getFlag().isPresent()) {
-        return String.valueOf(input.getFeatureFor(client));
+        return input.getFeatureFor(client);
       } else {
         return input.getWithFallback(client);
       }
@@ -27,8 +27,8 @@ public enum IntegrationTestFunction {
   },
   ENABLED("enabled") {
     @Override
-    public String apply(PrefabCloudClient client, IntegrationTestInput input) {
-      return String.valueOf(input.featureIsOnFor(client));
+    public Object apply(PrefabCloudClient client, IntegrationTestInput input) {
+      return input.featureIsOnFor(client);
     }
   };
 
@@ -54,5 +54,5 @@ public enum IntegrationTestFunction {
     return jsonValue;
   }
 
-  public abstract String apply(PrefabCloudClient client, IntegrationTestInput input);
+  public abstract Object apply(PrefabCloudClient client, IntegrationTestInput input);
 }

--- a/client/src/test/java/cloud/prefab/client/integration/IntegrationTestInput.java
+++ b/client/src/test/java/cloud/prefab/client/integration/IntegrationTestInput.java
@@ -1,6 +1,8 @@
 package cloud.prefab.client.integration;
 
 import cloud.prefab.client.PrefabCloudClient;
+import cloud.prefab.client.config.ConfigValueUtils;
+import cloud.prefab.client.value.LiveObject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
@@ -12,7 +14,7 @@ public class IntegrationTestInput {
   private final Optional<String> flag;
   private final String lookupKey;
   private final Map<String, Map<String, Object>> context;
-  private final Optional<String> defaultValue;
+  private final Optional<Object> defaultValue;
 
   @JsonCreator
   public IntegrationTestInput(
@@ -20,7 +22,7 @@ public class IntegrationTestInput {
     @JsonProperty("flag") Optional<String> flag,
     @JsonProperty("lookup_key") String lookupKey,
     @JsonProperty("context") Map<String, Map<String, Object>> context,
-    @JsonProperty("default") Optional<String> defaultValue
+    @JsonProperty("default") Optional<Object> defaultValue
   ) {
     this.key = key;
     this.flag = flag;
@@ -29,15 +31,17 @@ public class IntegrationTestInput {
     this.defaultValue = defaultValue;
   }
 
-  public String getWithFallback(PrefabCloudClient client) {
-    return client.configClient().liveString(getKey()).orElse(defaultValue.orElse(null));
+  public Object getWithFallback(PrefabCloudClient client) {
+    LiveObject liveObject = new LiveObject(client.configClient(), getKey());
+    return liveObject.orElse(defaultValue.orElse(null));
   }
 
-  public String getWithoutFallback(PrefabCloudClient client) {
+  public Object getWithoutFallback(PrefabCloudClient client) {
     if (defaultValue.isPresent()) {
       return getWithFallback(client);
     } else {
-      return client.configClient().liveString(getKey()).get();
+      LiveObject liveObject = new LiveObject(client.configClient(), getKey());
+      return liveObject.get();
     }
   }
 
@@ -67,7 +71,7 @@ public class IntegrationTestInput {
     return context;
   }
 
-  public Optional<String> getDefault() {
+  public Optional<Object> getDefault() {
     return defaultValue;
   }
 }

--- a/client/src/test/java/cloud/prefab/client/internal/WeightedValueEvaluatorTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/WeightedValueEvaluatorTest.java
@@ -28,7 +28,7 @@ class WeightedValueEvaluatorTest {
   RandomProviderIF randomProvider;
 
   @Mock
-  HashFunction hashFunction;
+  HashProvider hashProvider;
 
   @Mock
   HashCode hashCode;
@@ -73,10 +73,8 @@ class WeightedValueEvaluatorTest {
 
   @ParameterizedTest
   @MethodSource("provideArgumentsForHashingTrueFalse")
-  void itUsesHashFunctionWhenAble(int hashValue, boolean expectedValue) {
-    when(hashFunction.hashString("featureNamejames", StandardCharsets.UTF_8))
-      .thenReturn(hashCode);
-    when(hashCode.asInt()).thenReturn(hashValue);
+  void itUsesHashFunctionWhenAble(double hashValue, boolean expectedValue) {
+    when(hashProvider.hash("featureNamejames")).thenReturn(hashValue);
     Prefab.WeightedValues weightedValues = getTrueFalseConfig(
       500,
       500,
@@ -97,10 +95,8 @@ class WeightedValueEvaluatorTest {
 
   @ParameterizedTest
   @MethodSource("provideArgumentsForHashingFourWaySplit")
-  void itUsesHashFunctionWhenAbleFourWaySplit(int hashValue, int expectedValue) {
-    when(hashFunction.hashString("featureNamejames", StandardCharsets.UTF_8))
-      .thenReturn(hashCode);
-    when(hashCode.asInt()).thenReturn(hashValue);
+  void itUsesHashFunctionWhenAbleFourWaySplit(double hashValue, int expectedValue) {
+    when(hashProvider.hash("featureNamejames")).thenReturn(hashValue);
     Prefab.WeightedValues weightedValues = getMultiPartConfig(
       Optional.of("user.name"),
       10,
@@ -172,32 +168,19 @@ class WeightedValueEvaluatorTest {
 
   private static Stream<Arguments> provideArgumentsForHashingTrueFalse() {
     return Stream.of(
-      Arguments.of(Integer.MIN_VALUE, true),
-      Arguments.of(Integer.MIN_VALUE / 2, true),
-      Arguments.of(-1, true),
       Arguments.of(0, true),
-      Arguments.of(1, false),
-      Arguments.of(2, false),
-      Arguments.of(2000, false),
-      Arguments.of(20000, false),
-      Arguments.of(200000, false),
-      Arguments.of(Integer.MAX_VALUE / 2 - 10, false),
-      Arguments.of(Integer.MAX_VALUE / 2 + 10, false),
-      Arguments.of(Integer.MAX_VALUE, false)
+      Arguments.of(0.23, true),
+      Arguments.of(0.8, false),
+      Arguments.of(1, false)
     );
   }
 
   private static Stream<Arguments> provideArgumentsForHashingFourWaySplit() {
     return Stream.of(
-      Arguments.of(Integer.MIN_VALUE, 1),
-      Arguments.of(Integer.MIN_VALUE / 2, 1),
-      Arguments.of(-1, 2),
-      Arguments.of(0, 2),
-      Arguments.of(1, 3),
-      Arguments.of(2, 3),
-      Arguments.of(Integer.MAX_VALUE / 2 - 10, 3),
-      Arguments.of(Integer.MAX_VALUE / 2 + 10, 4),
-      Arguments.of(Integer.MAX_VALUE, 4)
+      Arguments.of(0, 1),
+      Arguments.of(0.3, 2),
+      Arguments.of(0.50001, 3),
+      Arguments.of(1, 4)
     );
   }
 


### PR DESCRIPTION
1) Fix weighted evaluator to match ruby, node (see comment on commit for details
2) changes to make integration tests use Objects over strings to better support non-String config value types