### PR TITLE
Use cdn again

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Maven
 <dependency>
     <groupId>cloud.prefab</groupId>
     <artifactId>client</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
 </dependency>
 ```
 

--- a/client/README.md
+++ b/client/README.md
@@ -13,7 +13,7 @@ Maven
 <dependency>
     <groupId>cloud.prefab</groupId>
     <artifactId>client</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
 </dependency>
 ```
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
+++ b/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
@@ -98,7 +98,7 @@ public class PrefabHttpClient {
     long offset
   ) {
     return requestConfigsFromURI(
-      URI.create(options.getPrefabApiUrl() + "/api/v1/configs/" + offset)
+      URI.create(options.getCDNUrl() + "/api/v1/configs/" + offset)
     );
   }
 

--- a/log4j-one-listener/README.md
+++ b/log4j-one-listener/README.md
@@ -13,7 +13,7 @@ Maven
 <dependency>
     <groupId>cloud.prefab</groupId>
     <artifactId>log4j-one-listener</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
 </dependency>
 ```
 

--- a/log4j-one-listener/pom.xml
+++ b/log4j-one-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
   </parent>
 
   <artifactId>log4j-one-listener</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>cloud.prefab</groupId>
       <artifactId>client</artifactId>
-      <version>0.3.10</version>
+      <version>0.3.11</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>cloud.prefab</groupId>
       <artifactId>client</artifactId>
-      <version>0.3.10</version>
+      <version>0.3.11</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/log4j-two-listener/README.md
+++ b/log4j-two-listener/README.md
@@ -12,7 +12,7 @@ Maven
 <dependency>
     <groupId>cloud.prefab</groupId>
     <artifactId>log4j-two-listener</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
 </dependency>
 ```
 

--- a/log4j-two-listener/pom.xml
+++ b/log4j-two-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
   </parent>
 
   <artifactId>log4j-two-listener</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>cloud.prefab</groupId>
       <artifactId>client</artifactId>
-      <version>0.3.10</version>
+      <version>0.3.11</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>cloud.prefab</groupId>
       <artifactId>client</artifactId>
-      <version>0.3.10</version>
+      <version>0.3.11</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/logback-listener/README.md
+++ b/logback-listener/README.md
@@ -15,7 +15,7 @@ Maven
 <dependency>
     <groupId>cloud.prefab</groupId>
     <artifactId>logback-listener</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
 </dependency>
 ```
 

--- a/logback-listener/pom.xml
+++ b/logback-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
   </parent>
 
   <artifactId>logback-listener</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>cloud.prefab</groupId>
       <artifactId>client</artifactId>
-      <version>0.3.10</version>
+      <version>0.3.11</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>cloud.prefab</groupId>
       <artifactId>client</artifactId>
-      <version>0.3.10</version>
+      <version>0.3.11</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/micronaut/README.md
+++ b/micronaut/README.md
@@ -21,7 +21,7 @@ Maven
 <dependency>
     <groupId>cloud.prefab</groupId>
     <artifactId>micronaut</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
 </dependency>
 ```
 

--- a/micronaut/pom.xml
+++ b/micronaut/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
   </parent>
 
   <artifactId>micronaut</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>cloud.prefab</groupId>
       <artifactId>client</artifactId>
-      <version>0.3.10</version>
+      <version>0.3.11</version>
     </dependency>
     <dependency>
       <groupId>io.micronaut</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>cloud.prefab</groupId>
   <artifactId>prefab-cloud-parent</artifactId>
-  <version>0.3.10</version>
+  <version>0.3.11</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
This fixes an issue introduced mid-April where requests to fetch config data from the CDN actually went to the prefab API instead