### PR TITLE
Update integration test data parsing

### DIFF
--- a/client/src/test/java/cloud/prefab/client/IntegrationTest.java
+++ b/client/src/test/java/cloud/prefab/client/IntegrationTest.java
@@ -1,6 +1,7 @@
 package cloud.prefab.client;
 
 import cloud.prefab.client.integration.IntegrationTestFile;
+import cloud.prefab.client.integration.IntegrationTestFileContents;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -48,7 +49,11 @@ public class IntegrationTest {
 
   private static IntegrationTestFile parseTestFile(Path testFile) {
     try {
-      return YAML_READER.readValue(testFile.toFile(), IntegrationTestFile.class);
+      IntegrationTestFileContents fileContents = YAML_READER.readValue(
+        testFile.toFile(),
+        IntegrationTestFileContents.class
+      );
+      return new IntegrationTestFile(fileContents, testFile);
     } catch (IOException e) {
       throw new RuntimeException("Error parsing test file: " + testFile, e);
     }

--- a/client/src/test/java/cloud/prefab/client/integration/IntegrationTestCaseDescriptor.java
+++ b/client/src/test/java/cloud/prefab/client/integration/IntegrationTestCaseDescriptor.java
@@ -92,6 +92,8 @@ public class IntegrationTestCaseDescriptor {
       .setInitializationTimeoutSec(1000);
 
     clientOverrides.getNamespace().ifPresent(options::setNamespace);
+    clientOverrides.getInitTimeoutSeconds().ifPresent(options::setInitializationTimeoutSec);
+
 
     return new PrefabCloudClient(options);
   }

--- a/client/src/test/java/cloud/prefab/client/integration/IntegrationTestCaseDescriptor.java
+++ b/client/src/test/java/cloud/prefab/client/integration/IntegrationTestCaseDescriptor.java
@@ -9,9 +9,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.errorprone.annotations.MustBeClosed;
+import java.util.Optional;
 import org.junit.jupiter.api.function.Executable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IntegrationTestCaseDescriptor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+    IntegrationTestCaseDescriptor.class
+  );
 
   private final String name;
   private final String client;
@@ -27,15 +34,32 @@ public class IntegrationTestCaseDescriptor {
     @JsonProperty("function") IntegrationTestFunction function,
     @JsonProperty("client_overrides") IntegrationTestClientOverrides clientOverrides,
     @JsonProperty("input") IntegrationTestInput input,
-    @JsonProperty("expected") IntegrationTestExpectation expected
+    @JsonProperty("expected") IntegrationTestExpectation expected,
+    @JsonProperty("aggregator") Optional<String> aggregator,
+    @JsonProperty("endpoint") Optional<String> endpoint,
+    @JsonProperty("data") Optional<Object> data,
+    @JsonProperty("expected_data") Optional<Object> expectedData
   ) {
     this.name = name;
     this.client = client;
     this.function = function;
+    LOG.info("test with name {} has function {}", name, function);
     this.clientOverrides =
       MoreObjects.firstNonNull(clientOverrides, IntegrationTestClientOverrides.empty());
     this.input = input;
     this.expected = expected;
+    if (aggregator.isPresent()) {
+      LOG.error("aggregator is not yet supported");
+    }
+    if (endpoint.isPresent()) {
+      LOG.error("endpoint is not yet supported");
+    }
+    if (data.isPresent()) {
+      LOG.error("data is not yet supported");
+    }
+    if (expectedData.isPresent()) {
+      LOG.error("expected_data is not yet supported");
+    }
   }
 
   public Executable asExecutable(PrefabContextSetReadable prefabContext) {
@@ -92,9 +116,19 @@ public class IntegrationTestCaseDescriptor {
       .setInitializationTimeoutSec(1000);
 
     clientOverrides.getNamespace().ifPresent(options::setNamespace);
-    clientOverrides.getInitTimeoutSeconds().ifPresent(options::setInitializationTimeoutSec);
+    clientOverrides
+      .getInitTimeoutSeconds()
+      .ifPresent(options::setInitializationTimeoutSec);
+    clientOverrides.getPrefabApiUrl().ifPresent(options::setPrefabApiUrl);
+    clientOverrides.getOnInitFailure().ifPresent(options::setOnInitializationFailure);
+    clientOverrides.getContextUploadMode().ifPresent(options::setContextUploadMode);
 
-
+    if (clientOverrides.getAggregator().isPresent()) {
+      LOG.error("clientOverrides-aggregator is not yet supported");
+    }
+    if (clientOverrides.getOnNoDefault().isPresent()) {
+      LOG.error("clientOverrides-onNoDefault is not yet supported");
+    }
     return new PrefabCloudClient(options);
   }
 }

--- a/client/src/test/java/cloud/prefab/client/integration/IntegrationTestClientOverrides.java
+++ b/client/src/test/java/cloud/prefab/client/integration/IntegrationTestClientOverrides.java
@@ -8,18 +8,25 @@ public class IntegrationTestClientOverrides {
 
   private final Optional<String> namespace;
   private final Optional<Integer> onNoDefault;
+  private final Optional<Integer> initTimeoutSeconds;
 
   @JsonCreator
   public IntegrationTestClientOverrides(
     @JsonProperty("namespace") Optional<String> namespace,
-    @JsonProperty("on_no_default") Optional<Integer> onNoDefault
+    @JsonProperty("on_no_default") Optional<Integer> onNoDefault,
+    @JsonProperty("initialization_timeout_sec") Optional<Integer> initTimeoutSeconds
   ) {
     this.namespace = namespace;
     this.onNoDefault = onNoDefault;
+    this.initTimeoutSeconds = initTimeoutSeconds;
   }
 
   public static IntegrationTestClientOverrides empty() {
-    return new IntegrationTestClientOverrides(Optional.empty(), Optional.empty());
+    return new IntegrationTestClientOverrides(
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty()
+    );
   }
 
   public Optional<String> getNamespace() {
@@ -28,5 +35,9 @@ public class IntegrationTestClientOverrides {
 
   public Optional<Integer> getOnNoDefault() {
     return onNoDefault;
+  }
+
+  public Optional<Integer> getInitTimeoutSeconds() {
+    return initTimeoutSeconds;
   }
 }

--- a/client/src/test/java/cloud/prefab/client/integration/IntegrationTestClientOverrides.java
+++ b/client/src/test/java/cloud/prefab/client/integration/IntegrationTestClientOverrides.java
@@ -1,5 +1,6 @@
 package cloud.prefab.client.integration;
 
+import cloud.prefab.client.Options;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
@@ -9,20 +10,61 @@ public class IntegrationTestClientOverrides {
   private final Optional<String> namespace;
   private final Optional<Integer> onNoDefault;
   private final Optional<Integer> initTimeoutSeconds;
+  private final Optional<String> prefabApiUrl;
+  private final Optional<Options.OnInitializationFailure> onInitFailure;
+  private final Optional<String> aggregator;
+  private final Optional<Options.CollectContextMode> contextUploadMode;
 
   @JsonCreator
   public IntegrationTestClientOverrides(
     @JsonProperty("namespace") Optional<String> namespace,
     @JsonProperty("on_no_default") Optional<Integer> onNoDefault,
-    @JsonProperty("initialization_timeout_sec") Optional<Integer> initTimeoutSeconds
+    @JsonProperty("initialization_timeout_sec") Optional<Integer> initTimeoutSeconds,
+    @JsonProperty("prefab_api_url") Optional<String> prefabApiUrl,
+    @JsonProperty("on_init_failure") Optional<String> onInitFailure,
+    @JsonProperty("aggregator") Optional<String> aggregator,
+    @JsonProperty("context_upload_mode") Optional<String> contextUploadMode
   ) {
     this.namespace = namespace;
     this.onNoDefault = onNoDefault;
     this.initTimeoutSeconds = initTimeoutSeconds;
+    this.prefabApiUrl = prefabApiUrl;
+    this.onInitFailure =
+      onInitFailure.map(text -> {
+        if (":return".equals(text)) {
+          return Options.OnInitializationFailure.UNLOCK;
+        }
+        if (":raise".equals(text)) {
+          return Options.OnInitializationFailure.RAISE;
+        }
+        throw new IllegalArgumentException(
+          String.format("Unexpected on_init_failure property value:`%s`", text)
+        );
+      });
+    this.aggregator = aggregator;
+    this.contextUploadMode =
+      contextUploadMode.map(text -> {
+        if (":shape_only".equals(text)) {
+          return Options.CollectContextMode.SHAPE_ONLY;
+        }
+        if (":none".equals(text)) {
+          return Options.CollectContextMode.NONE;
+        }
+        if (":periodic_example".equals(text)) {
+          return Options.CollectContextMode.PERIODIC_EXAMPLE;
+        }
+        throw new IllegalArgumentException(
+          String.format("Unexpected context_upload_mode property value:`%s`", text)
+        );
+      });
   }
 
   public static IntegrationTestClientOverrides empty() {
     return new IntegrationTestClientOverrides(
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty(),
+      Optional.empty(),
       Optional.empty(),
       Optional.empty(),
       Optional.empty()
@@ -39,5 +81,21 @@ public class IntegrationTestClientOverrides {
 
   public Optional<Integer> getInitTimeoutSeconds() {
     return initTimeoutSeconds;
+  }
+
+  public Optional<String> getPrefabApiUrl() {
+    return prefabApiUrl;
+  }
+
+  public Optional<Options.OnInitializationFailure> getOnInitFailure() {
+    return onInitFailure;
+  }
+
+  public Optional<String> getAggregator() {
+    return aggregator;
+  }
+
+  public Optional<Options.CollectContextMode> getContextUploadMode() {
+    return contextUploadMode;
   }
 }

--- a/client/src/test/java/cloud/prefab/client/integration/IntegrationTestExpectation.java
+++ b/client/src/test/java/cloud/prefab/client/integration/IntegrationTestExpectation.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.fail;
 
 import cloud.prefab.client.PrefabCloudClient;
+import cloud.prefab.client.PrefabInitializationTimeoutException;
 import cloud.prefab.client.integration.IntegrationTestExpectation.VerifyException;
 import cloud.prefab.client.integration.IntegrationTestExpectation.VerifyReturnValue;
 import cloud.prefab.client.value.UndefinedKeyException;
@@ -73,7 +74,9 @@ public interface IntegrationTestExpectation {
 
     private static final Map<String, Class<?>> ERROR_TYPES = ImmutableMap.of(
       "missing_default",
-      UndefinedKeyException.class
+      UndefinedKeyException.class,
+      "initialization_timeout",
+      PrefabInitializationTimeoutException.class
     );
 
     private final String error;

--- a/client/src/test/java/cloud/prefab/client/integration/IntegrationTestFileContents.java
+++ b/client/src/test/java/cloud/prefab/client/integration/IntegrationTestFileContents.java
@@ -1,37 +1,32 @@
 package cloud.prefab.client.integration;
 
 import cloud.prefab.context.PrefabContextSetReadable;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 
-public class IntegrationTestFile {
+public class IntegrationTestFileContents {
 
-  private final IntegrationTestFileContents contents;
-  private final Path path;
+  private final String version;
+  private final String function;
+  private final List<IntegrationTestDescriptor> tests;
 
-  public IntegrationTestFile(IntegrationTestFileContents contents, Path path) {
-    this.contents = contents;
-    this.path = path;
-  }
-
-  public String getVersion() {
-    return contents.getVersion();
-  }
-
-  public String getFunction() {
-    return contents.getFunction();
-  }
-
-  public List<IntegrationTestDescriptor> getTests() {
-    return contents.getTests();
+  @JsonCreator
+  public IntegrationTestFileContents(
+    @JsonProperty("version") String version,
+    @JsonProperty("function") String function,
+    @JsonProperty("tests") List<IntegrationTestDescriptor> tests
+  ) {
+    this.version = version;
+    this.function = function;
+    this.tests = tests;
   }
 
   public Stream<DynamicTest> buildDynamicTests() {
-    return getTests()
+    return tests
       .stream()
       .flatMap(testDescriptor -> {
         PrefabContextSetReadable contextSetReadable = testDescriptor.getPrefabContext();
@@ -43,9 +38,8 @@ public class IntegrationTestFile {
               .on(" : ")
               .useForNull("")
               .join(
-                getVersion(),
-                getFunction(),
-                path.getFileName().toString(),
+                version,
+                function,
                 testDescriptor.getName().orElse(null),
                 testCaseDescriptor.getName()
               );
@@ -55,5 +49,17 @@ public class IntegrationTestFile {
             );
           });
       });
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getFunction() {
+    return function;
+  }
+
+  public List<IntegrationTestDescriptor> getTests() {
+    return tests;
   }
 }


### PR DESCRIPTION
Throws when a non-supported config option is encountered but gets past deserialization.
Also adds the file name to the generated test name for easier debugging