### PR TITLE
Updated config change events

### DIFF
--- a/client/src/main/java/cloud/prefab/client/config/ConfigChangeEvent.java
+++ b/client/src/main/java/cloud/prefab/client/config/ConfigChangeEvent.java
@@ -1,7 +1,6 @@
 package cloud.prefab.client.config;
 
 import cloud.prefab.domain.Prefab;
-import cloud.prefab.domain.Prefab.ConfigValue;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -9,13 +8,13 @@ import java.util.StringJoiner;
 public class ConfigChangeEvent {
 
   private final String key;
-  private final Optional<Prefab.ConfigValue> oldValue;
-  private final Optional<Prefab.ConfigValue> newValue;
+  private final Optional<Prefab.Config> oldValue;
+  private final Optional<Prefab.Config> newValue;
 
   public ConfigChangeEvent(
     String key,
-    Optional<ConfigValue> oldValue,
-    Optional<ConfigValue> newValue
+    Optional<Prefab.Config> oldValue,
+    Optional<Prefab.Config> newValue
   ) {
     this.key = key;
     this.oldValue = oldValue;
@@ -26,11 +25,11 @@ public class ConfigChangeEvent {
     return key;
   }
 
-  public Optional<ConfigValue> getOldValue() {
+  public Optional<Prefab.Config> getOldValue() {
     return oldValue;
   }
 
-  public Optional<ConfigValue> getNewValue() {
+  public Optional<Prefab.Config> getNewValue() {
     return newValue;
   }
 

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigResolver.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigResolver.java
@@ -284,21 +284,10 @@ public class ConfigResolver {
     for (String key : sortedKeys) {
       ConfigElement configElement = configStore.getElement(key);
       try {
-        final Optional<Match> match = this.getMatch(key, LookupContext.EMPTY);
-        if (match.isPresent()) {
-          sb.append(padded(key, 45));
-          sb.append(
-            padded(
-              ConfigValueUtils
-                .toDisplayString(match.get().getConfigValue())
-                .orElse("[Unable to display]"),
-              40
-            )
-          );
-          sb.append(padded(configElement.getProvenance().toString(), 40));
-          sb.append(padded(match.get().getReason(), 40));
-          sb.append("\n");
-        }
+        sb.append(padded(key, 45));
+        sb.append(padded(configElement.getConfig().getConfigType().name(), 40));
+        sb.append(padded(configElement.getProvenance().toString(), 40));
+        sb.append("\n");
       } catch (ConfigValueException configValueException) {
         LOG.debug("Error rendering config with key '{}'", key, configValueException);
       }

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigStoreConfigValueDeltaCalculator.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigStoreConfigValueDeltaCalculator.java
@@ -5,13 +5,13 @@ import cloud.prefab.domain.Prefab;
 import java.util.Optional;
 
 public class ConfigStoreConfigValueDeltaCalculator
-  extends AbstractConfigStoreDeltaCalculator<Prefab.ConfigValue, ConfigChangeEvent> {
+  extends AbstractConfigStoreDeltaCalculator<Prefab.Config, ConfigChangeEvent> {
 
   @Override
   ConfigChangeEvent createEvent(
     String name,
-    Optional<Prefab.ConfigValue> oldValue,
-    Optional<Prefab.ConfigValue> newValue
+    Optional<Prefab.Config> oldValue,
+    Optional<Prefab.Config> newValue
   ) {
     return new ConfigChangeEvent(name, oldValue, newValue);
   }

--- a/client/src/main/java/cloud/prefab/client/internal/LoggingConfigListener.java
+++ b/client/src/main/java/cloud/prefab/client/internal/LoggingConfigListener.java
@@ -22,38 +22,17 @@ class LoggingConfigListener implements ConfigChangeListener {
   public void onChange(ConfigChangeEvent changeEvent) {
     if (systemInitializedSupplier.get()) {
       if (changeEvent.getNewValue().isEmpty()) {
-        LOG.info(
-          "Config value '{}' removed. Previous value was '{}'",
-          changeEvent.getKey(),
-          toJson(changeEvent.getOldValue().get())
-        );
+        LOG.info("Config value '{}' removed", changeEvent.getKey());
       } else if (changeEvent.getOldValue().isEmpty()) {
-        LOG.info(
-          "Config value '{}' added. New value is '{}'",
-          changeEvent.getKey(),
-          toJson(changeEvent.getNewValue().get())
-        );
+        LOG.info("Config value '{}' added", changeEvent.getKey());
       } else {
-        LOG.info(
-          "Config value '{}' updated. Previous value was '{}', new value is '{}'",
-          changeEvent.getKey(),
-          toJson(changeEvent.getOldValue().get()),
-          toJson(changeEvent.getNewValue().get())
-        );
+        LOG.info("Config value '{}' updated", changeEvent.getKey());
       }
     } else {
-      LOG.debug(
+      LOG.trace(
         "Not logging config change event {} before system initialization",
         changeEvent
       );
-    }
-  }
-
-  private static String toJson(ConfigValue configValue) {
-    try {
-      return JsonFormat.printer().omittingInsignificantWhitespace().print(configValue);
-    } catch (InvalidProtocolBufferException e) {
-      throw new RuntimeException("Error writing config value to json", e);
     }
   }
 }

--- a/client/src/main/java/cloud/prefab/client/internal/UpdatingConfigResolver.java
+++ b/client/src/main/java/cloud/prefab/client/internal/UpdatingConfigResolver.java
@@ -86,14 +86,14 @@ public class UpdatingConfigResolver {
   public ChangeLists update() {
     // catch exceptions resolving, treat as absent
     // store the old map
-    Map<String, Prefab.ConfigValue> before = buildValueMap();
+    Map<String, Prefab.Config> before = buildConfigByNameMap();
     Map<String, Prefab.LogLevel> logLevelsBefore = buildLogLevelValueMap();
 
     // load the new map
     makeLocal();
 
     // build the new map
-    Map<String, Prefab.ConfigValue> after = buildValueMap();
+    Map<String, Prefab.Config> after = buildConfigByNameMap();
     Map<String, Prefab.LogLevel> logLevelsAfter = buildLogLevelValueMap();
 
     return new ChangeLists(
@@ -122,14 +122,12 @@ public class UpdatingConfigResolver {
       );
   }
 
-  private Map<String, Prefab.ConfigValue> buildValueMap() {
+  private Map<String, Prefab.Config> buildConfigByNameMap() {
     return configStore
       .entrySet()
       .stream()
-      .map(entry ->
-        safeResolve(entry.getKey()).map(cv -> Maps.immutableEntry(entry.getKey(), cv))
-      )
-      .flatMap(Optional::stream)
+      .map(entry -> Maps.immutableEntry(entry.getKey(), entry.getValue().getConfig()))
+      .filter(entry -> entry.getValue().getRowsCount() > 0)
       .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 

--- a/client/src/test/java/cloud/prefab/client/internal/ConfigClientImplTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/ConfigClientImplTest.java
@@ -12,6 +12,7 @@ import cloud.prefab.client.PrefabCloudClient;
 import cloud.prefab.client.PrefabInitializationTimeoutException;
 import cloud.prefab.client.config.ConfigChangeEvent;
 import cloud.prefab.client.config.ConfigChangeListener;
+import cloud.prefab.client.config.ConfigValueUtils;
 import cloud.prefab.client.config.TestData;
 import cloud.prefab.client.config.TestUtils;
 import cloud.prefab.context.PrefabContext;
@@ -99,13 +100,41 @@ class ConfigClientImplTest {
         new ConfigChangeEvent(
           "sample_bool",
           Optional.empty(),
-          Optional.of(Prefab.ConfigValue.newBuilder().setBool(true).build())
+          Optional.of(
+            Prefab.Config
+              .newBuilder()
+              .addRows(
+                Prefab.ConfigRow
+                  .newBuilder()
+                  .addValues(
+                    Prefab.ConditionalValue
+                      .newBuilder()
+                      .setValue(ConfigValueUtils.from(true))
+                      .build()
+                  )
+                  .build()
+              )
+              .build()
+          )
         ),
         new ConfigChangeEvent(
           "sample",
           Optional.empty(),
           Optional.of(
-            Prefab.ConfigValue.newBuilder().setString("default sample value").build()
+            Prefab.Config
+              .newBuilder()
+              .addRows(
+                Prefab.ConfigRow
+                  .newBuilder()
+                  .addValues(
+                    Prefab.ConditionalValue
+                      .newBuilder()
+                      .setValue(ConfigValueUtils.from("default sample value"))
+                      .build()
+                  )
+                  .build()
+              )
+              .build()
           )
         )
       );

--- a/client/src/test/java/cloud/prefab/client/internal/UpdatingConfigResolverTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/UpdatingConfigResolverTest.java
@@ -45,33 +45,36 @@ public class UpdatingConfigResolverTest {
 
   @Test
   public void testUpdateChangeDetection() {
+    MergedConfigData startingTestData = testData();
     UpdatingConfigResolver.ChangeLists changeLists = resolver.update();
     assertThat(changeLists.getConfigChangeEvents())
       .containsExactlyInAnyOrder(
         new ConfigChangeEvent(
           "key1",
           Optional.empty(),
-          Optional.of(Prefab.ConfigValue.newBuilder().setString("value_none").build())
+          Optional.of(startingTestData.getConfigs().get("key1").getConfig())
         ),
         new ConfigChangeEvent(
           "key2",
           Optional.empty(),
-          Optional.of(Prefab.ConfigValue.newBuilder().setString("valueB2").build())
+          Optional.of(startingTestData.getConfigs().get("key2").getConfig())
         )
       );
+
+    MergedConfigData updatedTestData = testDataAddingKey3andTombstoningKey1();
 
     when(mockLoader.calcConfig()).thenReturn(testDataAddingKey3andTombstoningKey1());
     assertThat(resolver.update().getConfigChangeEvents())
       .containsExactlyInAnyOrder(
         new ConfigChangeEvent(
           "key1",
-          Optional.of(Prefab.ConfigValue.newBuilder().setString("value_none").build()),
+          Optional.of(startingTestData.getConfigs().get("key1").getConfig()),
           Optional.empty()
         ),
         new ConfigChangeEvent(
           "key3",
           Optional.empty(),
-          Optional.of(Prefab.ConfigValue.newBuilder().setString("key3").build())
+          Optional.of(updatedTestData.getConfigs().get("key3").getConfig())
         )
       );
   }

--- a/client/src/test/java/cloud/prefab/client/internal/UpdatingConfigResolverTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/UpdatingConfigResolverTest.java
@@ -140,8 +140,8 @@ public class UpdatingConfigResolverTest {
   public void testContentsString() {
     resolver.update();
     String expected =
-      "key1                                         value_none                              LOCAL_ONLY:unit test                                                            \n" +
-      "key2                                         valueB2                                 LOCAL_ONLY:unit test                                                            \n";
+      "key1                                         NOT_SET_CONFIG_TYPE                     LOCAL_ONLY:unit test                    \n" +
+      "key2                                         NOT_SET_CONFIG_TYPE                     LOCAL_ONLY:unit test                    \n";
     assertThat(resolver.contentsString()).isEqualTo(expected);
   }
 


### PR DESCRIPTION
As mentioned in #99 , this updates the ConfigChangedListener to have the before/after Config rather than ConfigValue.

This reduces the evaluations done, and better focuses things on the contextual targeting capabilities of the config system - eg it may be confusing to see the value set to "foo" but in actual usage with a context, the value will be something different