### PR TITLE
Fix sse keep alive handling

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>cloud.prefab</groupId>
       <artifactId>sse-handler</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/client/src/main/java/cloud/prefab/client/internal/SseConfigStreamingSubscriber.java
+++ b/client/src/main/java/cloud/prefab/client/internal/SseConfigStreamingSubscriber.java
@@ -101,11 +101,18 @@ public class SseConfigStreamingSubscriber {
       if (item instanceof DataEvent) {
         DataEvent dataEvent = (DataEvent) item;
         try {
-          Prefab.Configs configs = Prefab.Configs.parseFrom(
-            Base64.getDecoder().decode(dataEvent.getData().trim())
-          );
-          configConsumer.accept(configs);
-          hasReceivedData.setOpaque(true);
+          hasReceivedData.set(true);
+          String dataPayload = dataEvent.getData().trim();
+          if (!dataPayload.isEmpty()) {
+            Prefab.Configs configs = Prefab.Configs.parseFrom(
+              Base64.getDecoder().decode(dataPayload)
+            );
+            if (!configs.hasConfigServicePointer()) {
+              LOG.debug("Ignoring empty config keep-alive");
+            } else {
+              configConsumer.accept(configs);
+            }
+          }
         } catch (InvalidProtocolBufferException e) {
           LOG.warn(
             "Error parsing configs from event name {} - error message {}",


### PR DESCRIPTION
The underlying SSE-handler had a bug that was sending data events with empty payloads. This moves to a version of that without the problem, and additionally checks for configs w/o configServicePointer set that may be keep alives