### PR TITLE
Adds the concept of "baseContext" that can be set at prefab client startup time via options.

### DIFF
--- a/client/src/main/java/cloud/prefab/client/ConfigStore.java
+++ b/client/src/main/java/cloud/prefab/client/ConfigStore.java
@@ -1,7 +1,7 @@
 package cloud.prefab.client;
 
 import cloud.prefab.client.config.ConfigElement;
-import cloud.prefab.client.internal.DefaultContextWrapper;
+import cloud.prefab.client.internal.ContextWrapper;
 import java.util.Collection;
 
 public interface ConfigStore {
@@ -19,5 +19,15 @@ public interface ConfigStore {
 
   long getProjectEnvironmentId();
 
-  DefaultContextWrapper getDefaultContext();
+  /**
+   *
+   * @return the context sent from prefab - included with the config payload
+   */
+  ContextWrapper getConfigIncludedContext();
+
+  /**
+   *
+   * @return the context set in options before starting the prefab client
+   */
+  ContextWrapper getBaseContext();
 }

--- a/client/src/main/java/cloud/prefab/client/Options.java
+++ b/client/src/main/java/cloud/prefab/client/Options.java
@@ -6,6 +6,7 @@ import cloud.prefab.client.internal.PrefabInternal;
 import cloud.prefab.client.internal.TelemetryListener;
 import cloud.prefab.client.internal.ThreadLocalContextStore;
 import cloud.prefab.context.ContextStore;
+import cloud.prefab.context.PrefabContextSet;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -62,6 +63,9 @@ public class Options {
 
   @Nullable
   private TelemetryListener telemetryListener;
+
+  @Nullable
+  private PrefabContextSet baseContext;
 
   public Options() {
     this.apikey = System.getenv("PREFAB_API_KEY");
@@ -315,5 +319,14 @@ public class Options {
 
   public boolean isLocalDatafileMode() {
     return localDatafile != null;
+  }
+
+  public Optional<PrefabContextSet> getBaseContext() {
+    return Optional.ofNullable(baseContext);
+  }
+
+  public Options setBaseContext(@Nullable PrefabContextSet baseContext) {
+    this.baseContext = baseContext;
+    return this;
   }
 }

--- a/client/src/main/java/cloud/prefab/client/config/EvaluatedCriterion.java
+++ b/client/src/main/java/cloud/prefab/client/config/EvaluatedCriterion.java
@@ -2,6 +2,7 @@ package cloud.prefab.client.config;
 
 import cloud.prefab.domain.Prefab;
 import com.google.common.base.MoreObjects;
+import java.util.Objects;
 import java.util.Optional;
 
 public class EvaluatedCriterion {
@@ -73,5 +74,26 @@ public class EvaluatedCriterion {
       .add("evaluatedProperty", evaluatedProperty)
       .add("match", match)
       .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    EvaluatedCriterion that = (EvaluatedCriterion) o;
+    return (
+      match == that.match &&
+      Objects.equals(criterion, that.criterion) &&
+      Objects.equals(evaluatedProperty, that.evaluatedProperty)
+    );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(criterion, evaluatedProperty, match);
   }
 }

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigStoreImpl.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigStoreImpl.java
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ConfigStoreImpl implements ConfigStore {
 
   private final AtomicReference<MergedConfigData> data = new AtomicReference<>(
-    new MergedConfigData(Map.of(), 0, DefaultContextWrapper.empty())
+    new MergedConfigData(Map.of(), 0, ContextWrapper.empty(), ContextWrapper.empty())
   );
 
   @Override
@@ -47,7 +47,12 @@ public class ConfigStoreImpl implements ConfigStore {
   }
 
   @Override
-  public DefaultContextWrapper getDefaultContext() {
-    return data.get().getDefaultContextWrapper();
+  public ContextWrapper getConfigIncludedContext() {
+    return data.get().getConfigIncludedContext();
+  }
+
+  @Override
+  public ContextWrapper getBaseContext() {
+    return data.get().getBaseContextWrapper();
   }
 }

--- a/client/src/main/java/cloud/prefab/client/internal/ContextWrapper.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ContextWrapper.java
@@ -4,11 +4,13 @@ import cloud.prefab.domain.Prefab;
 import java.util.Collections;
 import java.util.Map;
 
-public class DefaultContextWrapper {
+public class ContextWrapper {
+
+  public static final ContextWrapper EMPTY = new ContextWrapper(Collections.emptyMap());
 
   private final Map<String, Prefab.ConfigValue> configValueMap;
 
-  public DefaultContextWrapper(Map<String, Prefab.ConfigValue> configValueMap) {
+  public ContextWrapper(Map<String, Prefab.ConfigValue> configValueMap) {
     this.configValueMap = configValueMap;
   }
 
@@ -16,7 +18,7 @@ public class DefaultContextWrapper {
     return configValueMap;
   }
 
-  public static DefaultContextWrapper empty() {
-    return new DefaultContextWrapper(Collections.emptyMap());
+  public static ContextWrapper empty() {
+    return EMPTY;
   }
 }

--- a/client/src/main/java/cloud/prefab/client/internal/MergedConfigData.java
+++ b/client/src/main/java/cloud/prefab/client/internal/MergedConfigData.java
@@ -7,27 +7,34 @@ public class MergedConfigData {
 
   private final Map<String, ConfigElement> configs;
   private final long envId;
-  private final DefaultContextWrapper defaultContextWrapper;
+  private final ContextWrapper baseContextWrapper;
+  private final ContextWrapper configIncludedContext;
 
   MergedConfigData(
     Map<String, ConfigElement> configs,
     long envId,
-    DefaultContextWrapper defaultContextWrapper
+    ContextWrapper baseContextWrapper,
+    ContextWrapper configIncludedContext
   ) {
     this.configs = configs;
     this.envId = envId;
-    this.defaultContextWrapper = defaultContextWrapper;
+    this.baseContextWrapper = baseContextWrapper;
+    this.configIncludedContext = configIncludedContext;
   }
 
   public Map<String, ConfigElement> getConfigs() {
     return configs;
   }
 
-  public DefaultContextWrapper getDefaultContextWrapper() {
-    return defaultContextWrapper;
+  public ContextWrapper getConfigIncludedContext() {
+    return configIncludedContext;
   }
 
   public long getEnvId() {
     return envId;
+  }
+
+  public ContextWrapper getBaseContextWrapper() {
+    return baseContextWrapper;
   }
 }

--- a/client/src/main/java/cloud/prefab/context/PrefabContextSet.java
+++ b/client/src/main/java/cloud/prefab/context/PrefabContextSet.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 
 public class PrefabContextSet implements PrefabContextSetReadable {
 
-  private ConcurrentSkipListMap<String, PrefabContext> contextByNameMap = new ConcurrentSkipListMap();
+  private final ConcurrentSkipListMap<String, PrefabContext> contextByNameMap = new ConcurrentSkipListMap<>();
 
   public void addContext(PrefabContext prefabContext) {
     if (prefabContext != null) {
@@ -38,15 +38,6 @@ public class PrefabContextSet implements PrefabContextSetReadable {
     return set;
   }
 
-  public static PrefabContextSet from(Prefab.ContextSet contextSet) {
-    PrefabContextSet set = new PrefabContextSet();
-    contextSet
-      .getContextsList()
-      .stream()
-      .forEach(p -> set.addContext(PrefabContext.fromProto(p)));
-    return set;
-  }
-
   /**
    * Converts the given `PrefabContextSetReadable` instance into a PrefabContextSet
    * If the argument is already a PrefabContextSet return it, othewise create a new PrefabContextSet and add the contents
@@ -72,6 +63,17 @@ public class PrefabContextSet implements PrefabContextSetReadable {
     getContexts()
       .forEach(prefabContext -> bldr.addContexts(prefabContext.toProtoContext()));
     return bldr.build();
+  }
+
+  public static PrefabContextSetReadable from(Prefab.ContextSet protoContextSet) {
+    if (protoContextSet.getContextsList().isEmpty()) {
+      return PrefabContextSet.EMPTY;
+    }
+    PrefabContextSet prefabContextSet = new PrefabContextSet();
+    for (Prefab.Context contextProto : protoContextSet.getContextsList()) {
+      prefabContextSet.addContext(PrefabContext.fromProto(contextProto));
+    }
+    return prefabContextSet;
   }
 
   @Override

--- a/client/src/main/java/cloud/prefab/context/PrefabContextSetReadable.java
+++ b/client/src/main/java/cloud/prefab/context/PrefabContextSetReadable.java
@@ -1,7 +1,11 @@
 package cloud.prefab.context;
 
+import cloud.prefab.domain.Prefab;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -11,6 +15,26 @@ public interface PrefabContextSetReadable {
   Iterable<PrefabContext> getContexts();
 
   boolean isEmpty();
+
+  default Map<String, Prefab.ConfigValue> flattenToImmutableMap() {
+    return Streams
+      .stream(getContexts())
+      .sorted(Comparator.comparing(PrefabContext::getName))
+      .flatMap(context ->
+        context
+          .getNameQualifiedProperties()
+          .entrySet()
+          .stream()
+          .sorted(Map.Entry.comparingByKey())
+      )
+      .collect(
+        ImmutableMap.toImmutableMap(
+          Map.Entry::getKey, // Key mapper
+          Map.Entry::getValue, // Value mapper
+          (existingValue, newValue) -> newValue
+        )
+      );
+  }
 
   PrefabContextSetReadable EMPTY = new PrefabContextSetReadable() {
     @Override

--- a/client/src/test/java/cloud/prefab/client/internal/UpdatingConfigResolverTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/UpdatingConfigResolverTest.java
@@ -93,7 +93,12 @@ public class UpdatingConfigResolverTest {
           .build()
       )
     );
-    return new MergedConfigData(config, TEST_PROJ_ENV, DefaultContextWrapper.empty());
+    return new MergedConfigData(
+      config,
+      TEST_PROJ_ENV,
+      ContextWrapper.empty(),
+      ContextWrapper.empty()
+    );
   }
 
   private Prefab.ConfigRow rowWithStringValue(String value) {
@@ -148,7 +153,12 @@ public class UpdatingConfigResolverTest {
     Map<String, ConfigElement> config = new HashMap<>();
     config.put("key1", ce(key1()));
     config.put("key2", ce(key2()));
-    return new MergedConfigData(config, TEST_PROJ_ENV, DefaultContextWrapper.empty());
+    return new MergedConfigData(
+      config,
+      TEST_PROJ_ENV,
+      ContextWrapper.empty(),
+      ContextWrapper.empty()
+    );
   }
 
   private ConfigElement ce(Prefab.Config config) {


### PR DESCRIPTION
Useful for unchanging data like a deployment name, server instance number and the like. Using options to set these means they're available outside of any request-specific context setting