### PR TITLE
Move context merging upstream

### DIFF
--- a/client/src/main/java/cloud/prefab/client/ConfigStore.java
+++ b/client/src/main/java/cloud/prefab/client/ConfigStore.java
@@ -1,7 +1,7 @@
 package cloud.prefab.client;
 
 import cloud.prefab.client.config.ConfigElement;
-import cloud.prefab.client.internal.ContextWrapper;
+import cloud.prefab.context.PrefabContextSetReadable;
 import java.util.Collection;
 
 public interface ConfigStore {
@@ -23,11 +23,11 @@ public interface ConfigStore {
    *
    * @return the context sent from prefab - included with the config payload
    */
-  ContextWrapper getConfigIncludedContext();
+  PrefabContextSetReadable getConfigIncludedContext();
 
   /**
    *
    * @return the context set in options before starting the prefab client
    */
-  ContextWrapper getGlobalContext();
+  PrefabContextSetReadable getGlobalContext();
 }

--- a/client/src/main/java/cloud/prefab/client/Options.java
+++ b/client/src/main/java/cloud/prefab/client/Options.java
@@ -6,7 +6,7 @@ import cloud.prefab.client.internal.PrefabInternal;
 import cloud.prefab.client.internal.TelemetryListener;
 import cloud.prefab.client.internal.ThreadLocalContextStore;
 import cloud.prefab.context.ContextStore;
-import cloud.prefab.context.PrefabContextSet;
+import cloud.prefab.context.PrefabContextSetReadable;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -65,7 +65,7 @@ public class Options {
   private TelemetryListener telemetryListener;
 
   @Nullable
-  private PrefabContextSet globalContext;
+  private PrefabContextSetReadable globalContext;
 
   public Options() {
     this.apikey = System.getenv("PREFAB_API_KEY");
@@ -321,11 +321,11 @@ public class Options {
     return localDatafile != null;
   }
 
-  public Optional<PrefabContextSet> getGlobalContext() {
+  public Optional<PrefabContextSetReadable> getGlobalContext() {
     return Optional.ofNullable(globalContext);
   }
 
-  public Options setGlobalContext(@Nullable PrefabContextSet globalContext) {
+  public Options setGlobalContext(@Nullable PrefabContextSetReadable globalContext) {
     this.globalContext = globalContext;
     return this;
   }

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigRuleEvaluator.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigRuleEvaluator.java
@@ -225,22 +225,6 @@ public class ConfigRuleEvaluator {
       }
     }
 
-    Optional<Prefab.ConfigValue> configValueFromGlobalContext = getPropFromContextWrapper(
-      keysToLookup,
-      configStore.getGlobalContext()
-    );
-    if (configValueFromGlobalContext.isPresent()) {
-      return configValueFromGlobalContext;
-    }
-
-    Optional<Prefab.ConfigValue> configValueFromApiDefaultContext = getPropFromContextWrapper(
-      keysToLookup,
-      configStore.getConfigIncludedContext()
-    );
-    if (configValueFromApiDefaultContext.isPresent()) {
-      return configValueFromApiDefaultContext;
-    }
-
     for (String keyToLookup : keysToLookup) {
       Prefab.ConfigValue valueFromLookupContext = lookupContext
         .getExpandedProperties()

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigStoreImpl.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigStoreImpl.java
@@ -2,6 +2,7 @@ package cloud.prefab.client.internal;
 
 import cloud.prefab.client.ConfigStore;
 import cloud.prefab.client.config.ConfigElement;
+import cloud.prefab.context.PrefabContextSetReadable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -10,7 +11,12 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ConfigStoreImpl implements ConfigStore {
 
   private final AtomicReference<MergedConfigData> data = new AtomicReference<>(
-    new MergedConfigData(Map.of(), 0, ContextWrapper.empty(), ContextWrapper.empty())
+    new MergedConfigData(
+      Map.of(),
+      0,
+      PrefabContextSetReadable.EMPTY,
+      PrefabContextSetReadable.EMPTY
+    )
   );
 
   @Override
@@ -47,12 +53,12 @@ public class ConfigStoreImpl implements ConfigStore {
   }
 
   @Override
-  public ContextWrapper getConfigIncludedContext() {
+  public PrefabContextSetReadable getConfigIncludedContext() {
     return data.get().getConfigIncludedContext();
   }
 
   @Override
-  public ContextWrapper getGlobalContext() {
-    return data.get().getGlobalContextWrapper();
+  public PrefabContextSetReadable getGlobalContext() {
+    return data.get().getGlobalContextSet();
   }
 }

--- a/client/src/main/java/cloud/prefab/client/internal/ContextMerger.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ContextMerger.java
@@ -6,14 +6,15 @@ import cloud.prefab.context.PrefabContextSetReadable;
 import com.google.common.base.Predicates;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 public class ContextMerger {
 
   public static PrefabContextSetReadable merge(
-    PrefabContextSetReadable globalContext,
-    PrefabContextSetReadable apiDefaultContext,
-    PrefabContextSetReadable contextStoreContext,
-    PrefabContextSetReadable passedContext
+    @Nullable PrefabContextSetReadable globalContext,
+    @Nullable PrefabContextSetReadable apiDefaultContext,
+    @Nullable PrefabContextSetReadable contextStoreContext,
+    @Nullable PrefabContextSetReadable passedContext
   ) {
     // use naive strategy for now,
     PrefabContextSet prefabContextSet = new PrefabContextSet();

--- a/client/src/main/java/cloud/prefab/client/internal/ContextMerger.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ContextMerger.java
@@ -1,0 +1,33 @@
+package cloud.prefab.client.internal;
+
+import cloud.prefab.context.PrefabContext;
+import cloud.prefab.context.PrefabContextSet;
+import cloud.prefab.context.PrefabContextSetReadable;
+import com.google.common.base.Predicates;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class ContextMerger {
+
+  public static PrefabContextSetReadable merge(
+    PrefabContextSetReadable globalContext,
+    PrefabContextSetReadable apiDefaultContext,
+    PrefabContextSetReadable contextStoreContext,
+    PrefabContextSetReadable passedContext
+  ) {
+    // use naive strategy for now,
+    PrefabContextSet prefabContextSet = new PrefabContextSet();
+
+    Stream
+      .of(globalContext, apiDefaultContext, contextStoreContext, passedContext)
+      .filter(Predicates.notNull())
+      .filter(Predicate.not(PrefabContextSetReadable::isEmpty))
+      .forEach(prefabContextSetReadable -> {
+        for (PrefabContext context : prefabContextSetReadable.getContexts()) {
+          prefabContextSet.addContext(context);
+        }
+      });
+
+    return prefabContextSet;
+  }
+}

--- a/client/src/main/java/cloud/prefab/client/internal/MergedConfigData.java
+++ b/client/src/main/java/cloud/prefab/client/internal/MergedConfigData.java
@@ -1,40 +1,41 @@
 package cloud.prefab.client.internal;
 
 import cloud.prefab.client.config.ConfigElement;
+import cloud.prefab.context.PrefabContextSetReadable;
 import java.util.Map;
 
 public class MergedConfigData {
 
   private final Map<String, ConfigElement> configs;
   private final long envId;
-  private final ContextWrapper globalContextWrapper;
-  private final ContextWrapper configIncludedContext;
+  private final PrefabContextSetReadable globalContextSet;
+  private final PrefabContextSetReadable configIncludedContextSet;
 
   MergedConfigData(
     Map<String, ConfigElement> configs,
     long envId,
-    ContextWrapper globalContextWrapper,
-    ContextWrapper configIncludedContext
+    PrefabContextSetReadable globalContextSet,
+    PrefabContextSetReadable configIncludedContextSet
   ) {
     this.configs = configs;
     this.envId = envId;
-    this.globalContextWrapper = globalContextWrapper;
-    this.configIncludedContext = configIncludedContext;
+    this.globalContextSet = globalContextSet;
+    this.configIncludedContextSet = configIncludedContextSet;
   }
 
   public Map<String, ConfigElement> getConfigs() {
     return configs;
   }
 
-  public ContextWrapper getConfigIncludedContext() {
-    return configIncludedContext;
+  public PrefabContextSetReadable getConfigIncludedContext() {
+    return configIncludedContextSet;
   }
 
   public long getEnvId() {
     return envId;
   }
 
-  public ContextWrapper getGlobalContextWrapper() {
-    return globalContextWrapper;
+  public PrefabContextSetReadable getGlobalContextSet() {
+    return globalContextSet;
   }
 }

--- a/client/src/main/java/cloud/prefab/client/internal/UpdatingConfigResolver.java
+++ b/client/src/main/java/cloud/prefab/client/internal/UpdatingConfigResolver.java
@@ -8,6 +8,7 @@ import cloud.prefab.client.config.Match;
 import cloud.prefab.client.config.Provenance;
 import cloud.prefab.client.config.logging.LogLevelChangeEvent;
 import cloud.prefab.client.exceptions.ConfigValueException;
+import cloud.prefab.context.PrefabContextSetReadable;
 import cloud.prefab.domain.Prefab;
 import com.google.common.collect.Maps;
 import java.util.Collection;
@@ -213,5 +214,13 @@ public class UpdatingConfigResolver {
 
   public Optional<Match> getRawMatch(String key, LookupContext lookupContext) {
     return configResolver.getRawMatch(key, lookupContext);
+  }
+
+  public PrefabContextSetReadable getApiDefaultContext() {
+    return configStore.getConfigIncludedContext();
+  }
+
+  public PrefabContextSetReadable getGlobalContext() {
+    return configStore.getGlobalContext();
   }
 }

--- a/client/src/main/java/cloud/prefab/context/PrefabContextSet.java
+++ b/client/src/main/java/cloud/prefab/context/PrefabContextSet.java
@@ -10,10 +10,11 @@ public class PrefabContextSet implements PrefabContextSetReadable {
 
   private final ConcurrentSkipListMap<String, PrefabContext> contextByNameMap = new ConcurrentSkipListMap<>();
 
-  public void addContext(PrefabContext prefabContext) {
+  public PrefabContextSet addContext(PrefabContext prefabContext) {
     if (prefabContext != null) {
       contextByNameMap.put(prefabContext.getName().toLowerCase(), prefabContext);
     }
+    return this;
   }
 
   public boolean isEmpty() {

--- a/client/src/test/java/cloud/prefab/client/integration/telemetry/ExampleContextIntegrationTestCaseDescriptor.java
+++ b/client/src/test/java/cloud/prefab/client/integration/telemetry/ExampleContextIntegrationTestCaseDescriptor.java
@@ -61,8 +61,6 @@ public class ExampleContextIntegrationTestCaseDescriptor
   protected void performVerification(PrefabCloudClient prefabCloudClient) {
     PrefabContextSet contextSetToSend = buildContextFromJsonNode(dataNode);
     PrefabContextSet expectedContextSet = buildContextFromJsonNode(expectedDataNode);
-    LOG.info("context set = {}", contextSetToSend);
-    LOG.info("expected context set = {}", expectedContextSet);
 
     prefabCloudClient.configClient().get("my-test-key", contextSetToSend);
     TelemetryAccumulator telemetryAccumulator = getTelemetryAccumulator(
@@ -79,6 +77,7 @@ public class ExampleContextIntegrationTestCaseDescriptor
           .map(Prefab.TelemetryEvent::getExampleContexts)
           .flatMap(c -> c.getExamplesList().stream())
           .flatMap(e -> e.getContextSet().getContextsList().stream())
+          .filter(c -> !c.getType().equals("prefab-api-key")) // ignore the context sent by api
           .collect(Collectors.toList());
 
         assertThat(actualContexts)

--- a/client/src/test/java/cloud/prefab/client/internal/ConfigLoaderTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/ConfigLoaderTest.java
@@ -286,11 +286,9 @@ public class ConfigLoaderTest {
     @Test
     void itReturnsGlobalContextFromCalcConfigAndEmptyApiDefaultContext() {
       MergedConfigData mergedConfigData = configLoader.calcConfig();
-      assertThat(mergedConfigData.getGlobalContextWrapper().getConfigValueMap())
-        .isEqualTo(globalContext.flattenToImmutableMap());
+      assertThat(mergedConfigData.getGlobalContextSet()).isEqualTo(globalContext);
 
-      assertThat(mergedConfigData.getConfigIncludedContext().getConfigValueMap())
-        .isEmpty();
+      assertThat(mergedConfigData.getConfigIncludedContext().isEmpty()).isTrue();
     }
 
     @Test
@@ -313,11 +311,10 @@ public class ConfigLoaderTest {
       );
 
       MergedConfigData mergedConfigData = configLoader.calcConfig();
-      assertThat(mergedConfigData.getGlobalContextWrapper().getConfigValueMap())
-        .isEqualTo(globalContext.flattenToImmutableMap());
+      assertThat(mergedConfigData.getGlobalContextSet()).isEqualTo(globalContext);
 
-      assertThat(mergedConfigData.getConfigIncludedContext().getConfigValueMap())
-        .isEqualTo(apiDefaultContext.flattenToImmutableMap());
+      assertThat(mergedConfigData.getConfigIncludedContext())
+        .isEqualTo(apiDefaultContext);
     }
   }
 

--- a/client/src/test/java/cloud/prefab/client/internal/ContextMergerTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/ContextMergerTest.java
@@ -1,0 +1,96 @@
+package cloud.prefab.client.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import cloud.prefab.context.PrefabContext;
+import cloud.prefab.context.PrefabContextSet;
+import cloud.prefab.context.PrefabContextSetReadable;
+import org.junit.jupiter.api.Test;
+
+class ContextMergerTest {
+
+  private static final PrefabContextSet GLOBAL = PrefabContextSet.from(
+    PrefabContext.newBuilder("a").put("ga-foo", "bar").put("ga-abc", 123).build(),
+    PrefabContext.newBuilder("b").put("gb-foo", "bar").put("gb-abc", 123).build(),
+    PrefabContext.newBuilder("global").put("sunny", "day").put("solar", 123).build()
+  );
+
+  private static final PrefabContextSet API = PrefabContextSet.from(
+    PrefabContext.newBuilder("a").put("api-a-foo", "bar").put("api-a-abc", 123).build(),
+    PrefabContext.newBuilder("b").put("api-a-foo", "bar").put("api-a-abc", 123).build(),
+    PrefabContext.newBuilder("api").put("cloudy", "day").put("solar", 234).build()
+  );
+
+  private static final PrefabContextSet CURRENT = PrefabContextSet.from(
+    PrefabContext
+      .newBuilder("a")
+      .put("current-a-foo", "bar")
+      .put("current-a-abc", 123)
+      .build(),
+    PrefabContext
+      .newBuilder("b")
+      .put("current-a-foo", "bar")
+      .put("current-a-abc", 123)
+      .build(),
+    PrefabContext.newBuilder("current").put("rainy", "day").put("solar", 456).build()
+  );
+
+  private static final PrefabContextSet PASSED = PrefabContextSet.from(
+    PrefabContext
+      .newBuilder("a")
+      .put("passed-a-foo", "bar")
+      .put("passed-a-abc", 123)
+      .build(),
+    PrefabContext
+      .newBuilder("b")
+      .put("passed-a-foo", "bar")
+      .put("passed-a-abc", 123)
+      .build(),
+    PrefabContext.newBuilder("passed").put("foggy", "day").put("solar", 345).build()
+  );
+
+  @Test
+  void itReturnsEmptyContextForAllNullArguments() {
+    assertThat(ContextMerger.merge(null, null, null, null).isEmpty()).isTrue();
+  }
+
+  @Test
+  void itReturnsEmptyContextForAllEmptyArguments() {
+    assertThat(
+      ContextMerger
+        .merge(
+          PrefabContextSetReadable.EMPTY,
+          PrefabContextSetReadable.EMPTY,
+          PrefabContextSetReadable.EMPTY,
+          PrefabContextSetReadable.EMPTY
+        )
+        .isEmpty()
+    )
+      .isTrue();
+  }
+
+  @Test
+  void itMergesGlobalWithApiInCorrectOrderWithoutPassedOrCurrentContext() {
+    PrefabContextSetReadable merged = ContextMerger.merge(GLOBAL, API, CURRENT, PASSED);
+    assertThat(merged)
+      .isEqualTo(
+        PASSED
+          .addContext(GLOBAL.getByName("global").get())
+          .addContext(API.getByName("api").get())
+          .addContext(CURRENT.getByName("current").get())
+      );
+  }
+
+  @Test
+  void itMergesAllContextsCorrectly() {
+    PrefabContextSetReadable merged = ContextMerger.merge(
+      GLOBAL,
+      API,
+      PrefabContextSetReadable.EMPTY,
+      PrefabContextSetReadable.EMPTY
+    );
+
+    assertThat(merged).isEqualTo(API.addContext(GLOBAL.getByName("global").get()));
+  }
+}

--- a/client/src/test/java/cloud/prefab/client/internal/UpdatingConfigResolverTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/UpdatingConfigResolverTest.java
@@ -10,6 +10,7 @@ import cloud.prefab.client.PrefabCloudClient;
 import cloud.prefab.client.config.ConfigChangeEvent;
 import cloud.prefab.client.config.ConfigElement;
 import cloud.prefab.client.config.Provenance;
+import cloud.prefab.context.PrefabContextSetReadable;
 import cloud.prefab.domain.Prefab;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -96,8 +97,8 @@ public class UpdatingConfigResolverTest {
     return new MergedConfigData(
       config,
       TEST_PROJ_ENV,
-      ContextWrapper.empty(),
-      ContextWrapper.empty()
+      PrefabContextSetReadable.EMPTY,
+      PrefabContextSetReadable.EMPTY
     );
   }
 
@@ -156,8 +157,8 @@ public class UpdatingConfigResolverTest {
     return new MergedConfigData(
       config,
       TEST_PROJ_ENV,
-      ContextWrapper.empty(),
-      ContextWrapper.empty()
+      PrefabContextSetReadable.EMPTY,
+      PrefabContextSetReadable.EMPTY
     );
   }
 


### PR DESCRIPTION
Previously the context lookups were accomplished by looking, in turn, at the global, api, and then the resolved lookup context. This approach meant that the telemetry stream of context shapes and context examples would be missing those elements of the context.
Now the config client incorporates the global and api contexts into the LookupContext