### PR TITLE
Revise config loading

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre2</version>
+    <version>0.3.22-pre4</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre4</version>
+    <version>0.3.22-pre5</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/client/src/main/java/cloud/prefab/client/Options.java
+++ b/client/src/main/java/cloud/prefab/client/Options.java
@@ -35,6 +35,7 @@ public class Options {
 
   private static final String DEFAULT_ENV = "default";
 
+  private String prefabDomain;
   private String prefabApiUrl;
   private String apikey;
   private String configOverrideDir;
@@ -69,10 +70,8 @@ public class Options {
 
   public Options() {
     this.apikey = System.getenv("PREFAB_API_KEY");
-    this.prefabApiUrl =
-      Optional
-        .ofNullable(System.getenv("PREFAB_API_URL"))
-        .orElse("https://api.prefab.cloud");
+    this.prefabDomain =
+      Optional.ofNullable(System.getenv("PREFAB_API_DOMAIN")).orElse("prefab.cloud");
     configOverrideDir = System.getProperty("user.home");
     if ("LOCAL_ONLY".equals(System.getenv("PREFAB_DATASOURCES"))) {
       prefabDatasources = Datasources.LOCAL_ONLY;
@@ -115,13 +114,28 @@ public class Options {
     return this;
   }
 
+  public String getPrefabDomain() {
+    return prefabDomain;
+  }
+
+  public Options setPrefabDomain(String prefabDomain) {
+    this.prefabDomain = prefabDomain;
+    return this;
+  }
+
   public String getPrefabApiUrl() {
-    return prefabApiUrl;
+    return Optional
+      .ofNullable(System.getenv("PREFAB_API_URL"))
+      .orElseGet(() -> "https://cdn." + prefabDomain);
   }
 
   public Options setPrefabApiUrl(String prefabApiUrl) {
     this.prefabApiUrl = prefabApiUrl;
     return this;
+  }
+
+  public String getPrefabTelemetryDomain() {
+    return "telemetry." + prefabDomain;
   }
 
   public List<String> getPrefabEnvs() {
@@ -235,18 +249,6 @@ public class Options {
   public Options setCollectEvaluationSummaries(boolean collectEvaluationSummaries) {
     this.collectEvaluationSummaries = collectEvaluationSummaries;
     return this;
-  }
-
-  public String getCDNUrl() {
-    String envVar = System.getenv("PREFAB_CDN_URL");
-    if (envVar != null) {
-      return envVar;
-    } else {
-      return String.format(
-        "%s.global.ssl.fastly.net",
-        prefabApiUrl.replaceAll("/$", "").replaceAll("\\.", "-")
-      );
-    }
   }
 
   public List<String> getAllPrefabEnvs() {

--- a/client/src/main/java/cloud/prefab/client/Options.java
+++ b/client/src/main/java/cloud/prefab/client/Options.java
@@ -7,6 +7,7 @@ import cloud.prefab.client.internal.TelemetryListener;
 import cloud.prefab.client.internal.ThreadLocalContextStore;
 import cloud.prefab.context.ContextStore;
 import cloud.prefab.context.PrefabContextSetReadable;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -71,7 +72,7 @@ public class Options {
   public Options() {
     this.apikey = System.getenv("PREFAB_API_KEY");
     this.prefabDomain =
-      Optional.ofNullable(System.getenv("PREFAB_API_DOMAIN")).orElse("prefab.cloud");
+      Optional.ofNullable(System.getenv("PREFAB_DOMAIN")).orElse("prefab.cloud");
     configOverrideDir = System.getProperty("user.home");
     if ("LOCAL_ONLY".equals(System.getenv("PREFAB_DATASOURCES"))) {
       prefabDatasources = Datasources.LOCAL_ONLY;
@@ -125,13 +126,20 @@ public class Options {
 
   public String getPrefabApiUrl() {
     return Optional
-      .ofNullable(System.getenv("PREFAB_API_URL"))
-      .orElseGet(() -> "https://cdn." + prefabDomain);
+      .ofNullable(System.getenv("PREFAB_API_URL_OVERRIDE"))
+      .orElseGet(() -> "https://" + getPrefabUrlHostNames().get(0) + "." + prefabDomain);
   }
 
   public Options setPrefabApiUrl(String prefabApiUrl) {
     this.prefabApiUrl = prefabApiUrl;
     return this;
+  }
+
+  public List<String> getPrefabUrlHostNames() {
+    return Optional
+      .ofNullable(System.getenv("PREFAB_HOSTNAMES"))
+      .map(e -> Splitter.on(',').splitToList(e))
+      .orElse(List.of("cdn"));
   }
 
   public String getPrefabTelemetryDomain() {

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
@@ -441,7 +441,7 @@ public class ConfigClientImpl implements ConfigClient {
   Optional<Prefab.Configs> loadConfigs() {
     try {
       HttpResponse<Supplier<Prefab.Configs>> response = prefabHttpClient
-        .requestConfigsFromApi(0)
+        .requestConfigs(0)
         .get(5, TimeUnit.SECONDS);
       LOG.info(
         "Got {} loading configs from API url {}",

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
@@ -138,8 +138,7 @@ public class ConfigClientImpl implements ConfigClient {
       ConnectivityTester connectivityTester = new ConnectivityTester(httpClient, options);
       connectivityTester.testHttps();
       prefabHttpClient = new PrefabHttpClient(httpClient, options);
-      startStreaming();
-      startCheckpointExecutor();
+      Executors.newSingleThreadExecutor().submit(this::startConnections);
       telemetryManager =
         new TelemetryManager(
           new LoggerStatsAggregator(Clock.systemUTC()),
@@ -152,6 +151,19 @@ public class ConfigClientImpl implements ConfigClient {
         );
       telemetryManager.start();
     }
+  }
+
+  private void startConnections() {
+    Optional<Prefab.Configs> configsMaybe = loadConfigs();
+    configsMaybe.ifPresent(configs -> {
+      long maxId = configs
+        .getConfigsList()
+        .stream()
+        .mapToLong(Prefab.Config::getId)
+        .max()
+        .orElse(0);
+      startStreaming(maxId);
+    });
   }
 
   @Override
@@ -426,52 +438,26 @@ public class ConfigClientImpl implements ConfigClient {
     };
   }
 
-  private void loadCheckpoint() {
-    boolean cdnSuccess = loadCDN();
-    if (cdnSuccess) {
-      return;
-    }
-    loadAPI();
-  }
-
-  boolean loadCDN() {
-    try {
-      HttpResponse<Supplier<Prefab.Configs>> response = prefabHttpClient
-        .requestConfigsFromCDN(0)
-        .get(5, TimeUnit.SECONDS);
-      if (PrefabHttpClient.isSuccess(response.statusCode())) {
-        loadConfigs(response.body().get(), Source.REMOTE_CDN);
-        return true;
-      }
-      LOG.info(
-        "Got {} loading configs from CDN url {}",
-        response.statusCode(),
-        response.request().uri()
-      );
-    } catch (Exception e) {
-      LOG.info("Got exception with message {} loading configs from CDN", e.getMessage());
-    }
-    return false;
-  }
-
-  boolean loadAPI() {
+  Optional<Prefab.Configs> loadConfigs() {
     try {
       HttpResponse<Supplier<Prefab.Configs>> response = prefabHttpClient
         .requestConfigsFromApi(0)
         .get(5, TimeUnit.SECONDS);
-      if (PrefabHttpClient.isSuccess(response.statusCode())) {
-        loadConfigs(response.body().get(), Source.REMOTE_API);
-        return true;
-      }
       LOG.info(
         "Got {} loading configs from API url {}",
         response.statusCode(),
         response.request().uri()
       );
+
+      if (PrefabHttpClient.isSuccess(response.statusCode())) {
+        Prefab.Configs configs = response.body().get();
+        loadConfigs(configs, Source.REMOTE_API);
+        return Optional.of(configs);
+      }
     } catch (Exception e) {
       LOG.info("Got exception with message {} loading configs from API", e.getMessage());
     }
-    return false;
+    return Optional.empty();
   }
 
   private ScheduledExecutorService startStreamingExecutor() {
@@ -487,7 +473,7 @@ public class ConfigClientImpl implements ConfigClient {
     );
   }
 
-  private void startStreaming() {
+  private void startStreaming(long highWaterMark) {
     ScheduledExecutorService scheduledExecutorService = startStreamingExecutor();
 
     LOG.info("Starting SSE config subscriber");
@@ -498,34 +484,6 @@ public class ConfigClientImpl implements ConfigClient {
       scheduledExecutorService
     );
     sseConfigStreamingSubscriber.start();
-  }
-
-  private void startCheckpointExecutor() {
-    ScheduledExecutorService executor = Executors.newScheduledThreadPool(
-      1,
-      r -> new Thread(r, "prefab-logger-checkpoint-executor")
-    );
-
-    ScheduledExecutorService scheduledExecutorService = MoreExecutors.getExitingScheduledExecutorService(
-      (ScheduledThreadPoolExecutor) executor,
-      100,
-      TimeUnit.MILLISECONDS
-    );
-
-    scheduledExecutorService.scheduleAtFixedRate(
-      () -> {
-        // allowing an exception to reach the ScheduledExecutor cancels future execution
-        // To prevent that we need to catch and log here
-        try {
-          loadCheckpoint();
-        } catch (Exception e) {
-          LOG.warn("Error getting checkpoint - will try again", e);
-        }
-      },
-      0,
-      DEFAULT_CHECKPOINT_SEC,
-      TimeUnit.SECONDS
-    );
   }
 
   private void finishInit(Source source) {

--- a/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigClientImpl.java
@@ -135,8 +135,6 @@ public class ConfigClientImpl implements ConfigClient {
           )
         )
         .build();
-      ConnectivityTester connectivityTester = new ConnectivityTester(httpClient, options);
-      connectivityTester.testHttps();
       prefabHttpClient = new PrefabHttpClient(httpClient, options);
       Executors.newSingleThreadExecutor().submit(this::startConnections);
       telemetryManager =

--- a/client/src/main/java/cloud/prefab/client/internal/ConnectivityTester.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConnectivityTester.java
@@ -23,7 +23,7 @@ class ConnectivityTester {
   public boolean testHttps() {
     HttpRequest request = HttpRequest
       .newBuilder()
-      .uri(URI.create(options.getPrefabApiUrl() + "/hello"))
+      .uri(URI.create(options.getApiHosts().get(0) + "/hello"))
       .build();
     try {
       HttpResponse<Void> response = httpClient.send(

--- a/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
+++ b/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
@@ -79,7 +79,7 @@ public class PrefabHttpClient {
     return httpClient.sendAsync(request, responseInfo -> asProto());
   }
 
-  CompletableFuture<HttpResponse<Void>> requestConfigSSE(
+  CompletableFuture<HttpResponse<Void>> createSSEConfigConnection(
     long offset,
     Flow.Subscriber<String> lineSubscriber
   ) {
@@ -99,9 +99,7 @@ public class PrefabHttpClient {
       .whenCompleteAsync(this::checkForAuthFailure);
   }
 
-  CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> requestConfigsFromApi(
-    long offset
-  ) {
+  CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> requestConfigs(long offset) {
     return requestConfigsFromURI(
       URI.create(options.getPrefabApiUrl() + "/api/v1/configs/" + offset)
     );

--- a/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
+++ b/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
@@ -40,10 +40,13 @@ public class PrefabHttpClient {
   private static final String START_AT_HEADER = "x-prefab-start-at-id";
   private final Options options;
   private final HttpClient httpClient;
+  private final URI telemetryUrl;
 
   PrefabHttpClient(HttpClient httpClient, Options options) {
     this.httpClient = httpClient;
     this.options = options;
+    this.telemetryUrl =
+      URI.create("https://" + options.getPrefabTelemetryDomain() + "/api/v1/telemetry");
   }
 
   private static HttpResponse.BodySubscriber<Supplier<Prefab.TelemetryEventsResponse>> asProto() {
@@ -68,7 +71,7 @@ public class PrefabHttpClient {
     HttpRequest request = getClientBuilderWithStandardHeaders()
       .header("Content-Type", PROTO_MEDIA_TYPE)
       .header("Accept", PROTO_MEDIA_TYPE)
-      .uri(URI.create(options.getPrefabApiUrl() + "/api/v1/telemetry"))
+      .uri(telemetryUrl)
       .POST(HttpRequest.BodyPublishers.ofByteArray(telemetryEvents.toByteArray()))
       .build();
     return httpClient.sendAsync(request, responseInfo -> asProto());
@@ -95,14 +98,6 @@ public class PrefabHttpClient {
   ) {
     return requestConfigsFromURI(
       URI.create(options.getPrefabApiUrl() + "/api/v1/configs/" + offset)
-    );
-  }
-
-  CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> requestConfigsFromCDN(
-    long offset
-  ) {
-    return requestConfigsFromURI(
-      URI.create(options.getCDNUrl() + "/api/v1/configs/" + offset)
     );
   }
 

--- a/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
+++ b/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
@@ -3,6 +3,9 @@ package cloud.prefab.client.internal;
 import cloud.prefab.client.Options;
 import cloud.prefab.client.util.MavenInfo;
 import cloud.prefab.domain.Prefab;
+import dev.failsafe.Failsafe;
+import dev.failsafe.Fallback;
+import dev.failsafe.RetryPolicy;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -12,9 +15,12 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,12 +47,14 @@ public class PrefabHttpClient {
   private final Options options;
   private final HttpClient httpClient;
   private final URI telemetryUrl;
+  private final List<String> apiHosts;
 
   PrefabHttpClient(HttpClient httpClient, Options options) {
     this.httpClient = httpClient;
     this.options = options;
     this.telemetryUrl =
-      URI.create("https://" + options.getPrefabTelemetryDomain() + "/api/v1/telemetry");
+      URI.create(options.getPrefabTelemetryHost() + "/api/v1/telemetry");
+    this.apiHosts = options.getApiHosts();
 
     LOG.info("Will send telemetry to {}", telemetryUrl);
   }
@@ -83,31 +91,31 @@ public class PrefabHttpClient {
     long offset,
     Flow.Subscriber<String> lineSubscriber
   ) {
-    URI uri = URI.create(options.getPrefabApiUrl() + "/api/v1/sse/config");
-
-    LOG.info("Requesting SSE from {}", uri);
-
-    HttpRequest request = getClientBuilderWithStandardHeaders()
-      .header("Accept", EVENT_STREAM_MEDIA_TYPE)
-      .header(START_AT_HEADER, String.valueOf(offset))
-      .timeout(Duration.ofSeconds(5))
-      .uri(uri)
-      .build();
-
-    return httpClient
-      .sendAsync(request, HttpResponse.BodyHandlers.fromLineSubscriber(lineSubscriber))
-      .whenCompleteAsync(this::checkForAuthFailure);
+    return executeWithFailover(host -> {
+      URI uri = URI.create(host + "/api/v1/sse/config");
+      LOG.info("Requesting SSE from {}", uri);
+      HttpRequest request = getClientBuilderWithStandardHeaders()
+        .header("Accept", EVENT_STREAM_MEDIA_TYPE)
+        .header(START_AT_HEADER, String.valueOf(offset))
+        .timeout(Duration.ofSeconds(5))
+        .uri(uri)
+        .build();
+      return httpClient
+        .sendAsync(request, HttpResponse.BodyHandlers.fromLineSubscriber(lineSubscriber))
+        .whenCompleteAsync(this::checkForAuthFailure);
+    });
   }
 
   CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> requestConfigs(long offset) {
-    return requestConfigsFromURI(
-      URI.create(options.getPrefabApiUrl() + "/api/v1/configs/" + offset)
+    return executeWithFailover(host ->
+      requestConfigsFromURI(URI.create(host + "/api/v1/configs/" + offset))
     );
   }
 
   private CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> requestConfigsFromURI(
     URI uri
   ) {
+    LOG.info("Requesting configs from {}", uri);
     HttpRequest request = getClientBuilderWithStandardHeaders()
       .header("Accept", PROTO_MEDIA_TYPE)
       .timeout(Duration.ofSeconds(5))
@@ -166,5 +174,40 @@ public class PrefabHttpClient {
         );
       }
     }
+  }
+
+  private <T> CompletableFuture<T> executeWithFailover(
+    Function<String, CompletableFuture<T>> operation
+  ) {
+    long maxRetriesPerHost = 2;
+    AtomicInteger hostIndex = new AtomicInteger(0);
+
+    RetryPolicy<T> retryPolicy = RetryPolicy
+      .<T>builder()
+      .handle(IOException.class, RuntimeException.class)
+      .handleResultIf(result -> {
+        if (result instanceof HttpResponse) {
+          int statusCode = ((HttpResponse<?>) result).statusCode();
+          return statusCode >= 500 && statusCode < 600;
+        }
+        return false;
+      })
+      .withBackoff(Duration.ofMillis(10), Duration.ofMillis(2000))
+      .withDelay(Duration.ofMillis(500))
+      .withMaxDuration(Duration.ofSeconds(5))
+      .withMaxRetries(Integer.MAX_VALUE)
+      .onFailedAttempt(executionAttemptedEvent -> {
+        if (executionAttemptedEvent.getAttemptCount() % maxRetriesPerHost == 0) {
+          hostIndex.incrementAndGet();
+        }
+      })
+      .build();
+
+    return Failsafe
+      .with(retryPolicy)
+      .getStageAsync(() -> {
+        String currentHost = apiHosts.get(hostIndex.get() % apiHosts.size());
+        return operation.apply(currentHost);
+      });
   }
 }

--- a/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
+++ b/client/src/main/java/cloud/prefab/client/internal/PrefabHttpClient.java
@@ -47,6 +47,8 @@ public class PrefabHttpClient {
     this.options = options;
     this.telemetryUrl =
       URI.create("https://" + options.getPrefabTelemetryDomain() + "/api/v1/telemetry");
+
+    LOG.info("Will send telemetry to {}", telemetryUrl);
   }
 
   private static HttpResponse.BodySubscriber<Supplier<Prefab.TelemetryEventsResponse>> asProto() {
@@ -81,11 +83,15 @@ public class PrefabHttpClient {
     long offset,
     Flow.Subscriber<String> lineSubscriber
   ) {
+    URI uri = URI.create(options.getPrefabApiUrl() + "/api/v1/sse/config");
+
+    LOG.info("Requesting SSE from {}", uri);
+
     HttpRequest request = getClientBuilderWithStandardHeaders()
       .header("Accept", EVENT_STREAM_MEDIA_TYPE)
       .header(START_AT_HEADER, String.valueOf(offset))
       .timeout(Duration.ofSeconds(5))
-      .uri(URI.create(options.getPrefabApiUrl() + "/api/v1/sse/config"))
+      .uri(uri)
       .build();
 
     return httpClient

--- a/client/src/main/java/cloud/prefab/client/internal/SseConfigStreamingSubscriber.java
+++ b/client/src/main/java/cloud/prefab/client/internal/SseConfigStreamingSubscriber.java
@@ -53,10 +53,14 @@ public class SseConfigStreamingSubscriber {
           hasReceivedData -> restart(hasReceivedData ? 1 : errorCount + 1)
         );
         sseHandler.subscribe(flowSubscriber);
-        prefabHttpClient.createSSEConfigConnection(
-          highwaterMarkSupplier.get(),
-          sseHandler
-        );
+        prefabHttpClient
+          .createSSEConfigConnection(highwaterMarkSupplier.get(), sseHandler)
+          .handle((ignored, throwable) -> {
+            if (throwable != null) {
+              LOG.warn("Error subscribing to SSE config", throwable);
+            }
+            return null;
+          });
       } catch (Exception e) {
         if (e.getMessage().contains("GOAWAY")) {
           LOG.debug("Got GOAWAY on SSE config stream, will restart connection.");

--- a/client/src/main/java/cloud/prefab/client/internal/SseConfigStreamingSubscriber.java
+++ b/client/src/main/java/cloud/prefab/client/internal/SseConfigStreamingSubscriber.java
@@ -2,6 +2,7 @@ package cloud.prefab.client.internal;
 
 import cloud.prefab.domain.Prefab;
 import cloud.prefab.sse.SSEHandler;
+import cloud.prefab.sse.events.CommentEvent;
 import cloud.prefab.sse.events.DataEvent;
 import cloud.prefab.sse.events.Event;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -52,7 +53,10 @@ public class SseConfigStreamingSubscriber {
           hasReceivedData -> restart(hasReceivedData ? 1 : errorCount + 1)
         );
         sseHandler.subscribe(flowSubscriber);
-        prefabHttpClient.requestConfigSSE(highwaterMarkSupplier.get(), sseHandler);
+        prefabHttpClient.createSSEConfigConnection(
+          highwaterMarkSupplier.get(),
+          sseHandler
+        );
       } catch (Exception e) {
         if (e.getMessage().contains("GOAWAY")) {
           LOG.debug("Got GOAWAY on SSE config stream, will restart connection.");
@@ -99,6 +103,10 @@ public class SseConfigStreamingSubscriber {
 
     @Override
     public void onNext(Event item) {
+      if (item instanceof CommentEvent) {
+        CommentEvent commentEvent = (CommentEvent) item;
+        LOG.info("Received comment event: {}", commentEvent);
+      }
       if (item instanceof DataEvent) {
         DataEvent dataEvent = (DataEvent) item;
         try {

--- a/client/src/test/java/cloud/prefab/client/PrefabOptionsTest.java
+++ b/client/src/test/java/cloud/prefab/client/PrefabOptionsTest.java
@@ -8,21 +8,21 @@ import org.junit.jupiter.api.Test;
 public class PrefabOptionsTest {
 
   @Test
-  public void testCDNUrl() {
+  public void testTelemetryDomain() {
     Options options = new Options();
+    assertThat(options.getPrefabTelemetryDomain()).isEqualTo("telemetry.prefab.cloud");
 
-    assertThat(options.getCDNUrl())
-      .isEqualTo("https://api-prefab-cloud.global.ssl.fastly.net");
+    options = new Options().setPrefabDomain("staging-prefab.cloud");
+    assertThat(options.getPrefabTelemetryDomain())
+      .isEqualTo("telemetry.staging-prefab.cloud");
+  }
 
-    options = new Options().setPrefabApiUrl("https://api.other-server.com");
-
-    assertThat(options.getCDNUrl())
-      .isEqualTo("https://api-other-server-com.global.ssl.fastly.net");
-
-    options = new Options().setPrefabApiUrl("https://api.other-server.com/");
-
-    assertThat(options.getCDNUrl())
-      .isEqualTo("https://api-other-server-com.global.ssl.fastly.net");
+  @Test
+  public void testApiDomain() {
+    Options options = new Options();
+    assertThat(options.getPrefabApiUrl()).isEqualTo("https://cdn.prefab.cloud");
+    options = new Options().setPrefabDomain("staging-prefab.cloud");
+    assertThat(options.getPrefabApiUrl()).isEqualTo("https://cdn.staging-prefab.cloud");
   }
 
   @Test

--- a/client/src/test/java/cloud/prefab/client/PrefabOptionsTest.java
+++ b/client/src/test/java/cloud/prefab/client/PrefabOptionsTest.java
@@ -10,19 +10,19 @@ public class PrefabOptionsTest {
   @Test
   public void testTelemetryDomain() {
     Options options = new Options();
-    assertThat(options.getPrefabTelemetryDomain()).isEqualTo("telemetry.prefab.cloud");
+    assertThat(options.getPrefabTelemetryHost())
+      .isEqualTo("https://telemetry.prefab.cloud");
 
-    options = new Options().setPrefabDomain("staging-prefab.cloud");
-    assertThat(options.getPrefabTelemetryDomain())
-      .isEqualTo("telemetry.staging-prefab.cloud");
+    options = new Options().setPrefabTelemetryHost("http://staging-prefab.cloud");
+    assertThat(options.getPrefabTelemetryHost()).isEqualTo("http://staging-prefab.cloud");
   }
 
   @Test
   public void testApiDomain() {
     Options options = new Options();
-    assertThat(options.getPrefabApiUrl()).isEqualTo("https://cdn.prefab.cloud");
-    options = new Options().setPrefabDomain("staging-prefab.cloud");
-    assertThat(options.getPrefabApiUrl()).isEqualTo("https://cdn.staging-prefab.cloud");
+    assertThat(options.getApiHosts()).isEqualTo(Options.DEFAULT_API_HOSTS);
+    options = new Options().setApiHosts(List.of("staging-prefab.cloud"));
+    assertThat(options.getApiHosts()).isEqualTo(List.of("https://staging-prefab.cloud"));
   }
 
   @Test

--- a/client/src/test/java/cloud/prefab/client/integration/BaseIntegrationTestCaseDescriptor.java
+++ b/client/src/test/java/cloud/prefab/client/integration/BaseIntegrationTestCaseDescriptor.java
@@ -85,12 +85,15 @@ public abstract class BaseIntegrationTestCaseDescriptor {
 
     Options options = new Options()
       .setApikey(apiKey)
-      .setPrefabDomain("staging-prefab.cloud")
-      .setInitializationTimeoutSec(1000);
+      .setPrefabTelemetryHost("https://telemetry.staging-prefab.cloud")
+      .setApiHosts(List.of("https://api.staging-prefab.cloud"))
+      .setInitializationTimeoutSec(2000);
     clientOverrides
       .getInitTimeoutSeconds()
       .ifPresent(options::setInitializationTimeoutSec);
-    clientOverrides.getPrefabApiUrl().ifPresent(options::setPrefabApiUrl);
+    clientOverrides
+      .getPrefabApiUrl()
+      .ifPresent(host -> options.setApiHosts(List.of(host)));
     clientOverrides.getOnInitFailure().ifPresent(options::setOnInitializationFailure);
     clientOverrides.getContextUploadMode().ifPresent(options::setContextUploadMode);
     globalContextMaybe.ifPresent(options::setGlobalContext);

--- a/client/src/test/java/cloud/prefab/client/integration/BaseIntegrationTestCaseDescriptor.java
+++ b/client/src/test/java/cloud/prefab/client/integration/BaseIntegrationTestCaseDescriptor.java
@@ -85,7 +85,7 @@ public abstract class BaseIntegrationTestCaseDescriptor {
 
     Options options = new Options()
       .setApikey(apiKey)
-      .setPrefabApiUrl("https://api.staging-prefab.cloud")
+      .setPrefabDomain("staging-prefab.cloud")
       .setInitializationTimeoutSec(1000);
     clientOverrides
       .getInitTimeoutSeconds()

--- a/client/src/test/java/cloud/prefab/client/internal/PrefabHttpClientTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/PrefabHttpClientTest.java
@@ -1,0 +1,126 @@
+package cloud.prefab.client.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import cloud.prefab.client.Options;
+import cloud.prefab.domain.Prefab;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Flow;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PrefabHttpClientTest {
+
+  @Mock
+  HttpClient mockHttpClient;
+
+  Options options = new Options()
+    .setApiHosts(List.of("http://a.example.com", "http://b.example.com"))
+    .setApikey("not-a-real-key");
+
+  @Test
+  void testFailoverForConfigFetch() throws ExecutionException, InterruptedException {
+    PrefabHttpClient prefabHttpClient = new PrefabHttpClient(mockHttpClient, options);
+
+    // Create a mock Prefab.Configs object
+    Prefab.Configs mockConfigs = Prefab.Configs.newBuilder().build();
+
+    // Mock responses: fail twice, then succeed
+    HttpResponse<Supplier<Prefab.Configs>> failureResponse = mock(HttpResponse.class);
+    when(failureResponse.statusCode()).thenReturn(500);
+
+    HttpResponse<Supplier<Prefab.Configs>> successResponse = mock(HttpResponse.class);
+    when(successResponse.statusCode()).thenReturn(200);
+    when(successResponse.body()).thenReturn(() -> mockConfigs);
+
+    // Set up the mock behavior
+    CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> failureFuture = CompletableFuture.completedFuture(
+      failureResponse
+    );
+    CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> successFuture = CompletableFuture.completedFuture(
+      successResponse
+    );
+
+    when(
+      mockHttpClient.sendAsync(
+        any(HttpRequest.class),
+        any(HttpResponse.BodyHandler.class)
+      )
+    )
+      .thenReturn(failureFuture)
+      .thenReturn(failureFuture)
+      .thenReturn(successFuture);
+
+    // Test method
+    CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> result = prefabHttpClient.requestConfigs(
+      0L
+    );
+
+    // Wait for the result
+    HttpResponse<Supplier<Prefab.Configs>> response = result.get();
+
+    // Verify
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body().get()).isEqualTo(mockConfigs);
+    verify(mockHttpClient, times(3)).sendAsync(any(), any());
+  }
+
+  @Test
+  void testFailoverForSSEConnection() throws ExecutionException, InterruptedException {
+    PrefabHttpClient prefabHttpClient = new PrefabHttpClient(mockHttpClient, options);
+
+    // Mock responses: fail twice, then succeed
+    HttpResponse<Supplier<Prefab.Configs>> failureResponse = mock(HttpResponse.class);
+    when(failureResponse.statusCode()).thenReturn(500);
+
+    HttpResponse<Supplier<Prefab.Configs>> successResponse = mock(HttpResponse.class);
+    when(successResponse.statusCode()).thenReturn(200);
+
+    Flow.Subscriber<String> lineSubscriber = mock(Flow.Subscriber.class);
+
+    // Set up the mock behavior
+    CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> failureFuture = CompletableFuture.completedFuture(
+      failureResponse
+    );
+    CompletableFuture<HttpResponse<Supplier<Prefab.Configs>>> successFuture = CompletableFuture.completedFuture(
+      successResponse
+    );
+
+    when(
+      mockHttpClient.sendAsync(
+        any(HttpRequest.class),
+        any(HttpResponse.BodyHandler.class)
+      )
+    )
+      .thenReturn(failureFuture)
+      .thenReturn(failureFuture)
+      .thenReturn(successFuture);
+
+    // Test method
+    CompletableFuture<HttpResponse<Void>> responseFuture = prefabHttpClient.createSSEConfigConnection(
+      0L,
+      lineSubscriber
+    );
+
+    // Wait for the result
+    var response = responseFuture.get();
+
+    // Verify
+    assertThat(response.statusCode()).isEqualTo(200);
+    verify(mockHttpClient, times(3)).sendAsync(any(), any());
+  }
+}

--- a/log4j-one-listener/pom.xml
+++ b/log4j-one-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre2</version>
+    <version>0.3.22-pre4</version>
   </parent>
 
   <artifactId>log4j-one-listener</artifactId>

--- a/log4j-one-listener/pom.xml
+++ b/log4j-one-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre4</version>
+    <version>0.3.22-pre5</version>
   </parent>
 
   <artifactId>log4j-one-listener</artifactId>

--- a/log4j-two-listener/pom.xml
+++ b/log4j-two-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre4</version>
+    <version>0.3.22-pre5</version>
   </parent>
 
   <artifactId>log4j-two-listener</artifactId>

--- a/log4j-two-listener/pom.xml
+++ b/log4j-two-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre2</version>
+    <version>0.3.22-pre4</version>
   </parent>
 
   <artifactId>log4j-two-listener</artifactId>

--- a/logback-listener/pom.xml
+++ b/logback-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre2</version>
+    <version>0.3.22-pre4</version>
   </parent>
 
   <artifactId>logback-listener</artifactId>

--- a/logback-listener/pom.xml
+++ b/logback-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre4</version>
+    <version>0.3.22-pre5</version>
   </parent>
 
   <artifactId>logback-listener</artifactId>

--- a/micronaut/pom.xml
+++ b/micronaut/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre2</version>
+    <version>0.3.22-pre4</version>
   </parent>
 
   <artifactId>micronaut</artifactId>

--- a/micronaut/pom.xml
+++ b/micronaut/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>cloud.prefab</groupId>
     <artifactId>prefab-cloud-parent</artifactId>
-    <version>0.3.22-pre4</version>
+    <version>0.3.22-pre5</version>
   </parent>
 
   <artifactId>micronaut</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>cloud.prefab</groupId>
   <artifactId>prefab-cloud-parent</artifactId>
-  <version>0.3.22-pre4</version>
+  <version>0.3.22-pre5</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>cloud.prefab</groupId>
   <artifactId>prefab-cloud-parent</artifactId>
-  <version>0.3.22-pre2</version>
+  <version>0.3.22-pre4</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
Two major changes here

1) Don't start SSE and config connection at the same time; also don't poll the config connection anymore. Instead, fetch configuration then build an SSE connection based on the current high water mark

2) Add failover across our new belt/suspenders hosts