### PR TITLE
Add support for 'reforge.current-time' property key

### DIFF
--- a/client/src/main/java/cloud/prefab/client/internal/ConfigRuleEvaluator.java
+++ b/client/src/main/java/cloud/prefab/client/internal/ConfigRuleEvaluator.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 public class ConfigRuleEvaluator {
 
   public static final String CURRENT_TIME_KEY = "prefab.current-time";
+  public static final String REFORGE_CURRENT_TIME_KEY = "reforge.current-time";
   private static final Logger LOG = LoggerFactory.getLogger(ConfigRuleEvaluator.class);
 
   private final ConfigStore configStore;
@@ -242,7 +243,7 @@ public class ConfigRuleEvaluator {
       }
     }
     //TODO: move this current time injection into a ContextResolver class?
-    if (CURRENT_TIME_KEY.equals(key)) {
+    if (CURRENT_TIME_KEY.equals(key) || REFORGE_CURRENT_TIME_KEY.equals(key)) {
       return Optional.of(
         Prefab.ConfigValue.newBuilder().setInt(System.currentTimeMillis()).build()
       );

--- a/client/src/test/java/cloud/prefab/client/internal/ConfigRuleEvaluatorTest.java
+++ b/client/src/test/java/cloud/prefab/client/internal/ConfigRuleEvaluatorTest.java
@@ -583,6 +583,57 @@ public class ConfigRuleEvaluatorTest {
     assertThat(eval.isMatch()).isFalse();
   }
 
+  @Test
+  public void testReforgeTimeInRange() {
+    // note this relies on ConfigRuleEvaluator on-demand adding the current time for reforge.current-time
+    final Prefab.Criterion intRangeCriterion = Prefab.Criterion
+      .newBuilder()
+      .setPropertyName(ConfigRuleEvaluator.REFORGE_CURRENT_TIME_KEY)
+      .setValueToMatch(
+        Prefab.ConfigValue.newBuilder().setIntRange(Prefab.IntRange.newBuilder().build())
+      )
+      .setOperator(Prefab.Criterion.CriterionOperator.IN_INT_RANGE)
+      .build();
+
+    final EvaluatedCriterion positiveEval = evaluator
+      .evaluateCriterionMatch(intRangeCriterion, LookupContext.EMPTY)
+      .stream()
+      .findFirst()
+      .get();
+
+    assertThat(positiveEval.isMatch()).isTrue();
+  }
+
+  @Test
+  public void testReforgeTimeAfterRange() {
+    // note this relies on ConfigRuleEvaluator on-demand adding the current time for reforge.current-time
+    long currentTime = System.currentTimeMillis();
+
+    final Prefab.Criterion intRangeCriterion = Prefab.Criterion
+      .newBuilder()
+      .setPropertyName(ConfigRuleEvaluator.REFORGE_CURRENT_TIME_KEY)
+      .setValueToMatch(
+        Prefab.ConfigValue
+          .newBuilder()
+          .setIntRange(
+            Prefab.IntRange
+              .newBuilder()
+              .setEnd(currentTime - TimeUnit.MINUTES.toMillis(2))
+              .build()
+          )
+      )
+      .setOperator(Prefab.Criterion.CriterionOperator.IN_INT_RANGE)
+      .build();
+
+    final EvaluatedCriterion eval = evaluator
+      .evaluateCriterionMatch(intRangeCriterion, LookupContext.EMPTY)
+      .stream()
+      .findFirst()
+      .get();
+
+    assertThat(eval.isMatch()).isFalse();
+  }
+
   public static Stream<Arguments> comparisonArguments() {
     return Stream.of(
       Arguments.of(


### PR DESCRIPTION
## Summary
• Add support for 'reforge.current-time' property key alongside existing 'prefab.current-time'
• Maintain backward compatibility while providing SDK compatibility with reforge naming
• Both property keys now provide identical current timestamp functionality

## Changes
• Added `REFORGE_CURRENT_TIME_KEY` constant in ConfigRuleEvaluator
• Updated `prop()` method to handle both time property keys with OR condition
• Added comprehensive test cases covering both time key variants

## Test plan
- [x] Existing tests for 'prefab.current-time' continue to pass
- [x] New tests verify 'reforge.current-time' works identically
- [x] Both keys provide current system time in milliseconds
- [x] Time range evaluation works correctly for both keys

This change maintains full backward compatibility while adding the requested reforge SDK compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)